### PR TITLE
Remove the 'beta' label from the header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,9 +8,7 @@
 			</a>
 			<a href="/" class="logo">
 				Digital Transformation Agency
-			</a> <!--span class="badge--default">draft</span-->
-			<span class="badge&#45;&#45;default">BETA</span>
-
+			</a>
 		</div>
 
 		<!--<nav id="mob-menu" class="global-nav alpha7-mob-menu">-->


### PR DESCRIPTION
This removes the 'beta' label from the header, along with the 'draft' label in the HTML comment.
