### PR TITLE
set some headers for cdn/cache

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -36,6 +36,7 @@ http {
   map $sent_http_content_type $expires {
     default                    off;
     text/html                  epoch;
+    text/xml                   epoch;
     text/css                   max;
     application/javascript     max;
     ~image/                    max;


### PR DESCRIPTION
This correctly sets up the cache control headers sdo that the site is CDN friendly.

This uses mimetypes for setting up the cache headers.

https://www.digitalocean.com/community/tutorials/how-to-implement-browser-caching-with-nginx-s-header-module-on-ubuntu-16-04?comment=52082

No cache for html
max cache for other assets

The last setting is for ~image/, which is a regular expression that will match all file types containing
image/ in their MIME type name (like image/jpg and image/png). Like stylesheets, there are often a lot
of images on websites that can be safely cached, so we set this to max as well.


## TESTS

### HTML
```
[~/src/github.com/AusDTO/dta-website]
lunix@dto]  (cdn) -> curl -I http://mpc.apps.staging.digital.gov.au/index.html
HTTP/1.1 200 OK
Accept-Ranges: bytes
Cache-Control: no-cache
Content-Length: 20995
Content-Type: text/html; charset=utf-8
Date: Fri, 11 Nov 2016 03:41:47 GMT
Etag: "58253a14-5203"
Expires: Thu, 01 Jan 1970 00:00:01 GMT
Last-Modified: Fri, 11 Nov 2016 03:25:08 GMT
Server: nginx
X-Cf-Requestid: d5ad3718-6b5e-425e-6df4-1e94a477b574
Connection: keep-alive
```

### IMAGE
```
[~/src/github.com/AusDTO/dta-website]
lunix@dto]  (cdn) -> curl -I http://mpc.apps.staging.digital.gov.au/marketplace-user-needs-thumb-046f4169dd2b2cb996af89abde553a8257958d4354723341f69eabf9fd5e98cf.jpg
HTTP/1.1 200 OK
Accept-Ranges: bytes
Cache-Control: max-age=315360000
Content-Length: 32379
Content-Type: image/jpeg
Date: Fri, 11 Nov 2016 03:41:54 GMT
Etag: "58253a14-7e7b"
Expires: Thu, 31 Dec 2037 23:55:55 GMT
Last-Modified: Fri, 11 Nov 2016 03:25:08 GMT
Server: nginx
X-Cf-Requestid: ae4953d1-dfba-4268-57e4-2cb9ec4dae0e
Connection: keep-alive
```