### PR TITLE
Update opengraph tags

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,29 +4,45 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="shortcut icon" type="image/x-icon" href="{{ site.url }}/images/icons/favicon.ico">
 
-  <!-- Social/unfurl  http://ogp.me/ , https://dev.twitter.com/cards/types/summary-->
+{% if page.title %}
+  <title>{{ page.title }} | {{ site.title }}</title>
+  <meta property="og:title" content="{{ page.title | xml_escape }}" />
+  <meta name="twitter:title" content="{{ page.title | xml_escape }}" />
+{% else %}
+  <title>{{ site.title }}</title>
+  <meta property="og:title" content="{{ site.title | xml_escape }}" />
+  <meta name="twitter:title" content="{{ site.title | xml_escape }}" />
+{% endif %}
+
+{% assign social-image = 'dta-unfurl' %}
+{% if page.og-image %}
+  {% assign social-image = page.og-image %}
+{% endif %}
+{% assign social-description = page.content | markdownify | strip_html | strip_newlines | truncatewords:50 %}
+{% if page.searchexcerpt%}
+  {% assign social-description= page.searchexcerpt | strip_html | strip_newlines | truncate: 50 %}
+{% endif %}
+
+{% assign url= page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url %}
+
   <meta property="og:locale" content="en_AU" />
-  <meta property="og:title" content="{% if page.title %}{{ page.title }} | {{ site.title }}{% else %}{{ site.title }}{% endif %}" />
-  <meta property="og:type" content="Website" />
-  <meta property="og:image" content="{{ site.url }}{% asset_path dta-unfurl %}" />
-  <meta property="og:url" content="{{ site.url }}" />
-  <meta property="og:description" content="{% if page.searchexcerpt %}{{ page.searchexcerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="{{ site.url }}{{ social-image | asset_path }}" />
+  <meta property="og:url" content="{{ url }}" />
+  <meta property="og:description" content="{{ social-description }}" />
+  <meta property="og:site_name" content="{{ site.title }}" />
   <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="{% if page.searchexcerpt %}{{ page.searchexcerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}" />
-  <meta name="twitter:title" content="{{ page.title }}" />
-  <meta name="twitter:site" content="@DTO" />
-  <meta name="twitter:image" content="{{ site.url }}{% asset_path dta-unfurl %}" />
-
-  <title>{% if page.title %}{{ page.title }} | {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
-
-  <meta name="description" content="{% if page.searchexcerpt %}{{ page.searchexcerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
+  <meta name="twitter:description" content="{{ social-description }}" />
+  <meta name="twitter:site" content="@{{ site.twitter }}" />
+  <meta name="twitter:image" content="{{ site.url }}{{ social-image | asset_path }}" />
+  <meta name="description" content="{{ site.description }}">
   <meta name="creator" content="Digital Transformation Agency">
 
   {% if page.author %}<meta name="author" content="{{ page.author}}">{% endif %}
 
   <meta name="type" content="Text">
   <meta name="modified" content="{{ page.date | date: "%b %-d, %Y" }}">
-  <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+  <link rel="canonical" href="{{ url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
 
   {% include google_fonts.html %}

--- a/_posts/2016-11-18-marketplace-roundtable.md
+++ b/_posts/2016-11-18-marketplace-roundtable.md
@@ -7,6 +7,7 @@ category: blog
 tag: marketplace
 hero-image: mp-roundtable-image06
 thumbnail: mp-roundtable-thumb
+og-image: mp-roundtable-image06
 ---
 
 ![Montage of images showing audience and presenters at the Digital Transformation Roundtable]({{site.url}}{{page.hero-image | asset_path }})

--- a/_posts/2016-11-22-how-the-bom-put-users-needs-first.md
+++ b/_posts/2016-11-22-how-the-bom-put-users-needs-first.md
@@ -6,6 +6,7 @@ category: blog
 tag: ''
 hero-image: bom-app-content
 thumbnail: bom-app-thumb
+og-image: bom-app-content
 ---
 
 **This is a guest post by Jenny Hunter, Head of Digital, Bureau of Meteorology.**


### PR DESCRIPTION
The og-image is a temporary fix. Given the current mix of hero-images being half jekyll-assets, and half not, it was tough to fix it for all cases, so have added a temp front matter tag `og-image`. After resolving the hero-image issue, should remove it.