### PR TITLE
Add support for running jekyll in cloudfoundry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,5 @@ gem 'font-awesome-sass'
 gem 'uglifier'
 gem 'rake'
 
+gem 'rack-jekyll'
+gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,12 @@ GEM
     parallel (1.9.0)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
+    puma (3.6.2)
     rack (1.6.4)
+    rack-jekyll (0.5.0)
+      jekyll (>= 1.3)
+      listen (>= 1.3)
+      rack (~> 1.5)
     rake (11.3.0)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
@@ -105,6 +110,8 @@ DEPENDENCIES
   jekyll-assets
   jekyll-redirect-from
   jekyll-sitemap
+  puma
+  rack-jekyll
   rake
   therubyracer
   uglifier

--- a/Rakefile
+++ b/Rakefile
@@ -43,3 +43,11 @@ task :ui_kit_update do
   file.write Net::HTTP.get(URI.parse(UIKIT_JS))
 
 end
+
+# When run on cf with the ruby buildpack, this will build
+# the jekyll site as part of the assets pipeline
+namespace :assets do
+  task :precompile do
+    puts `bundle exec jekyll build`
+  end
+end

--- a/_config.yml
+++ b/_config.yml
@@ -45,6 +45,7 @@ exclude:
   - circle.yml
   - README.md
   - manifest*.yml
+  - ld_library_path
 
 assets:
   assets:

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,3 @@
+require "rack/jekyll"
+
+run Rack::Jekyll.new

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,7 @@
 ---
-
-path: _site/
-instances: 1
-memory: 64M
-disk_quota: 256M
-buildpack: staticfile_buildpack
+applications:
+- buildpack: https://github.com/cloudfoundry/ruby-buildpack.git
+  memory: 512M
+  instances: 1
+  path: .
+  command: 'bundle exec puma -t 8:32 -w 3 -p $PORT'


### PR DESCRIPTION
The static buildpack relies on 'bundle exec jekyll build' having been run before the 'cf push'. This commit changes to use the ruby build pack, so we can build the site as part of the assets pipeline. The files are then served in a puma webserver.

This means [QA Fire](https://qafire.apps.staging.digital.gov.au/4) can now be used.