### PR TITLE
Add pa11y to CI tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ _site
 dta-website.iml
 .idea
 .DS_Store
+node_modules
 

--- a/.pa11yci
+++ b/.pa11yci
@@ -1,11 +1,12 @@
 {
   "defaults": {
     "hideElements":
-      ".skip-to, .is-visuallyhidden"
+      ".skip-to, .is-visuallyhidden, iframe"
   },
 
   "urls": [
     "http://localhost:4000/",
-    "http://localhost:4000/what-we-do/"
+    "http://localhost:4000/what-we-do/",
+    "http://localhost:4000/blog/how-the-bom-put-users-needs-first/"
   ]
 }

--- a/.pa11yci
+++ b/.pa11yci
@@ -1,0 +1,11 @@
+{
+  "defaults": {
+    "hideElements":
+      ".skip-to, .is-visuallyhidden"
+  },
+
+  "urls": [
+    "http://localhost:4000/",
+    "http://localhost:4000/what-we-do/"
+  ]
+}

--- a/.pa11yci
+++ b/.pa11yci
@@ -1,5 +1,5 @@
 {
   "defaults": {
-    "hideElements": ".skip-to, .is-visuallyhidden, iframe"
+    "hideElements": ".skip-to, .is-visuallyhidden, .visuallyhidden, iframe"
   }
 }

--- a/.pa11yci
+++ b/.pa11yci
@@ -1,12 +1,5 @@
 {
   "defaults": {
-    "hideElements":
-      ".skip-to, .is-visuallyhidden, iframe"
-  },
-
-  "urls": [
-    "http://localhost:4000/",
-    "http://localhost:4000/what-we-do/",
-    "http://localhost:4000/blog/how-the-bom-put-users-needs-first/"
-  ]
+    "hideElements": ".skip-to, .is-visuallyhidden, iframe"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ www.dta.gov.au is a [Jekyll website](http://jekyllrb.com/).
 - [Ruby 2.3.1](https://www.ruby-lang.org/en/documentation/installation/)
 - [rbenv](https://github.com/rbenv/rbenv)
 - [Bundler](http://bundler.io/)
+- [Node.js](https://nodejs.org) (For pa11y tests)
 
 Run each of the following commands to get the site running locally:
 
@@ -23,6 +24,20 @@ Run each of the following commands to get the site running locally:
 You should be able to see the site at: http://127.0.0.1:4000
 
 To increase the speed of jekyll builds, you can replace the last step with `bin/serve`. This will disable the search plugin and only render the latest post.
+
+### Run tests locally
+
+Install pa11y-ci and it's dependencies with:
+
+`npm install pa11y-ci@^0.4`
+
+Make sure you have the app running locally with:
+
+`bundle exec jekyll serve`
+
+Run the tests with:
+
+`bin/citest.sh`
 
 ## Development Process
 

--- a/_assets/scss/main.scss
+++ b/_assets/scss/main.scss
@@ -29,7 +29,7 @@ $dta-red: #d7002f;
 //not to be used for text. Only to be used as background with white text - minumium 20px and bold
 $discovery: #912b87;
 $alpha: #c52a72;
-$beta: #ef6a30;
+$beta: #cf4a10;
 $live: #859949;
 
 

--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ collections:
   assessment-reports:
     output: true
   projects:
-    output: true
+    output: false
   teams:
     output: true
   leadership-group:

--- a/_config.yml
+++ b/_config.yml
@@ -47,6 +47,7 @@ exclude:
   - manifest*.yml
   - ld_library_path
   - config.ru
+  - node_modules
 
 assets:
   assets:

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -13,7 +13,7 @@
       </a>
       {% endif %}
       <div class="site-search">
-        <form id="search" class="" action="/search/" role="search" method="get">
+        <form action="/search/" role="search" method="get">
           <label for="site-search-text">Search dta.gov.au</label>
           <div class="site-search-border">
             <input type="search" name="q" id="site-search-text" title="Search" class="search-input" />

--- a/_includes/search.html
+++ b/_includes/search.html
@@ -1,6 +1,6 @@
 <div id="search">
     <form id="search-form" action="/search/" method="get">
-        <label for="q">Search dta.gov.au</label>
+        <label for="search-query">Search dta.gov.au</label>
         <input name="q" id="search-query" type="text" autocomplete="on"/>
         <input type="submit" value="Search">
     </form>

--- a/_includes/search.html
+++ b/_includes/search.html
@@ -1,4 +1,4 @@
-<div id="search">
+<div>
     <form id="search-form" action="/search/" method="get">
         <label for="search-query">Search dta.gov.au</label>
         <input name="q" id="search-query" type="text" autocomplete="on"/>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -23,9 +23,9 @@ layout: base
       <li>
         <figure>
           {% if post.thumbnail %}
-          <a href="{{ url }}"><img class="blog-thumbnail" src="{{ post.thumbnail | asset_path }}" alt=""></a>
+          <a href="{{ url }}"><img class="blog-thumbnail" src="{{ post.thumbnail | asset_path }}" alt="Read post {{ post.title }}"></a>
           {% else %}
-          <a href="{{ url }}"><img class="blog-thumbnail" src="{% asset_path post-thumbnail-placeholder %}" alt=""></a>
+          <a href="{{ url }}"><img class="blog-thumbnail" src="{% asset_path post-thumbnail-placeholder %}" alt="Read post {{ post.title }}"></a>
           {% endif %}
         </figure>
         <article>

--- a/bin/cideploy.sh
+++ b/bin/cideploy.sh
@@ -17,6 +17,9 @@ basicauth() {
   fi
 }
 
+# We dont need to deploy the pa11y-sitemap.xml
+rm -f _site/pa11y-sitemap.xml
+
 # main script function
 #
 main() {

--- a/bin/ciprepare.sh
+++ b/bin/ciprepare.sh
@@ -22,5 +22,5 @@ cf -v
 sudo apt-get update
 sudo apt-get install -qy apache2-utils
 
-npm install -g pa11y-ci
+npm install pa11y-ci@^0.4
 

--- a/bin/ciprepare.sh
+++ b/bin/ciprepare.sh
@@ -22,3 +22,5 @@ cf -v
 sudo apt-get update
 sudo apt-get install -qy apache2-utils
 
+npm install -g pa11y-ci
+

--- a/bin/ciserve.sh
+++ b/bin/ciserve.sh
@@ -1,0 +1,1 @@
+bundle exec jekyll serve --incremental

--- a/bin/ciserve.sh
+++ b/bin/ciserve.sh
@@ -1,1 +1,12 @@
-bundle exec jekyll serve --incremental
+#!/usr/bin/env bash
+
+# Exit immediately if there is an error
+set -e
+
+# cause a pipeline (for example, curl -s http://sipb.mit.edu/ | grep foo) to produce a failure return code if any command errors not just the last command of the pipeline.
+set -o pipefail
+
+# echo out each line of the shell as it executes
+set -x
+
+bundle exec jekyll serve

--- a/bin/citest.sh
+++ b/bin/citest.sh
@@ -4,10 +4,11 @@
 # EXPECTS THE SITE TO HAVE ALREADY BEEN BUILT AND RUNNING LOCALLY
 #
 
-printf "Waiting for webserver to start"
+echo "Waiting for webserver to start..."
 until $(curl --output /dev/null --silent --head --fail http://localhost:4000); do
     sleep 5
 done
+echo "Webserver has started"
 
 # Exit immediately if there is an error
 set -e
@@ -19,7 +20,7 @@ set -o pipefail
 set -x
 
 #Run pa11y accessibility tests against the local running copy
-pa11y-ci --sitemap http://localhost:4000/sitemap.xml
+pa11y-ci --sitemap http://localhost:4000/pa11y-sitemap.xml
 
 # Run jekyll hyde
 # Note - this will clobber the sitemap.xml using the site.url, so we just use production's

--- a/bin/citest.sh
+++ b/bin/citest.sh
@@ -20,7 +20,7 @@ set -o pipefail
 set -x
 
 #Run pa11y accessibility tests against the local running copy
-pa11y-ci --sitemap http://localhost:4000/pa11y-sitemap.xml
+node_modules/.bin/pa11y-ci --sitemap http://localhost:4000/pa11y-sitemap.xml
 
 # Run jekyll hyde
 # Note - this will clobber the sitemap.xml using the site.url, so we just use production's

--- a/bin/citest.sh
+++ b/bin/citest.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 
 #
-# EXPECTS THE SITE TO HAVE ALREADY BEEN BUILT
+# EXPECTS THE SITE TO HAVE ALREADY BEEN BUILT AND RUNNING LOCALLY
 #
+
+printf "Waiting for webserver to start"
+until $(curl --output /dev/null --silent --head --fail http://localhost:4000); do
+    sleep 5
+done
 
 # Exit immediately if there is an error
 set -e
@@ -13,13 +18,7 @@ set -o pipefail
 # echo out each line of the shell as it executes
 set -x
 
-printf "Waiting for webserver to start"
-until $(curl --output /dev/null --silent --head --fail http://localhost:4000); do
-    printf '.'
-    sleep 5
-done
-
-#Run accessibility tests
+#Run pa11y accessibility tests against the local running copy
 pa11y-ci --sitemap http://localhost:4000/sitemap.xml
 
 # Run jekyll hyde

--- a/bin/citest.sh
+++ b/bin/citest.sh
@@ -13,6 +13,12 @@ set -o pipefail
 # echo out each line of the shell as it executes
 set -x
 
+printf "Waiting for webserver to start"
+until $(curl --output /dev/null --silent --head --fail http://localhost:4000); do
+    printf '.'
+    sleep 5
+done
+
 #Run accessibility tests
 pa11y-ci --sitemap http://localhost:4000/sitemap.xml
 

--- a/bin/citest.sh
+++ b/bin/citest.sh
@@ -13,6 +13,8 @@ set -o pipefail
 # echo out each line of the shell as it executes
 set -x
 
+#Run accessibility tests
+pa11y-ci --sitemap http://localhost:4000/sitemap.xml
 
 # Run jekyll hyde
 # Note - this will clobber the sitemap.xml using the site.url, so we just use production's

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ dependencies:
 test:
   override:
     - bin/cibuild.sh
-    - bin/ciserve.sh
+    - bin/ciserve.sh:
           background: true
     - sleep 5
     - bin/citest.sh

--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,7 @@ test:
   override:
     - bin/cibuild.sh
     - bin/ciserve.sh
-        background: true
+          background: true
     - sleep 5
     - bin/citest.sh
 

--- a/circle.yml
+++ b/circle.yml
@@ -16,7 +16,6 @@ test:
     - bin/cibuild.sh
     - bin/ciserve.sh:
           background: true
-    - sleep 5
     - bin/citest.sh
 
 deployment:

--- a/circle.yml
+++ b/circle.yml
@@ -14,6 +14,9 @@ dependencies:
 test:
   override:
     - bin/cibuild.sh
+    - bin/ciserve.sh
+        background: true
+    - sleep 5
     - bin/citest.sh
 
 deployment:

--- a/google7a46798bcc50a03a.html
+++ b/google7a46798bcc50a03a.html
@@ -1,1 +1,5 @@
+---
+layout: null
+sitemap: false
+---
 google-site-verification: google7a46798bcc50a03a.html

--- a/pa11y-sitemap.xml
+++ b/pa11y-sitemap.xml
@@ -1,0 +1,50 @@
+---
+layout: null
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
+        xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+
+    {% for post in site.posts %}{% unless post.sitemap == false %}
+
+    <url>
+        <loc>{{ post.url | prepend: site.url }}</loc>
+        {% if post.last_modified_at %}
+        <lastmod>{{ post.last_modified_at | date_to_xmlschema }}</lastmod>
+        {% else %}
+        <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
+        {% endif %}
+    </url>
+    {% endunless %}{% endfor %}
+    {% for page in site.html_pages %}
+        {% unless page.sitemap == false %}
+    <url>
+        <loc>{{ page.url | replace:'/index.html','/' | prepend: site.url }}</loc>
+        {% if page.last_modified_at %}
+        <lastmod>{{ page.last_modified_at | date_to_xmlschema }}</lastmod>
+        {% endif %}
+    </url>
+        {% endunless %}
+    {% endfor %}
+    {% for collection in site.collections %}
+        {% unless collection.last.output == false %}
+            {% for doc in collection.last.docs %}
+                {% unless doc.sitemap == false %}
+    <url>
+        <loc>{{ doc.url | replace:'/index.html','/' | prepend: site.url }}</loc>
+                    {% if doc.last_modified_at %}
+        <lastmod>{{ doc.last_modified_at | date_to_xmlschema }}</lastmod>
+                    {% endif %}
+    </url>
+                {% endunless %}
+            {% endfor %}
+        {% endunless %}
+    {% endfor %}
+    {% for file in site.html_files %}
+    <url>
+        <loc>{{ file.path | prepend: site.url }}</loc>
+        <lastmod>{{ file.modified_time | date_to_xmlschema }}</lastmod>
+    </url>
+    {% endfor %}
+</urlset>

--- a/pages/blog/index.html
+++ b/pages/blog/index.html
@@ -16,9 +16,9 @@ permalink: /blog/
     <li>
       <figure>
         {% if post.thumbnail %}
-        <a href="{{ post.url }}"><img class="blog-thumbnail" src="{{ post.thumbnail | asset_path }}" alt=""></a>
+        <a href="{{ post.url }}"><img class="blog-thumbnail" src="{{ post.thumbnail | asset_path }}" alt="Read post {{ post.title }}"></a>
         {% else %}
-        <a href="{{ post.url }}"><img class="blog-thumbnail" src="{% asset_path blog-thumbnail-placeholder %}" alt=""></a>
+        <a href="{{ post.url }}"><img class="blog-thumbnail" src="{% asset_path blog-thumbnail-placeholder %}" alt="Read post {{ post.title }}"></a>
         {% endif %}
       </figure>
       <article>

--- a/pages/footer-links/signup.html
+++ b/pages/footer-links/signup.html
@@ -44,9 +44,9 @@ title: "Sign up for blog updates"
         <div class="response" id="mce-success-response" style="display:none"></div>
       </div>
       <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-      <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text"
-                                                                                name="b_81bbb1d15242b2224ee11e3fe_427c57f270"
-                                                                                tabindex="-1" value=""></div>
+      <div style="position: absolute; left: -5000px;" aria-hidden="true" class="is-visuallyhidden">
+        <input type="text" name="b_81bbb1d15242b2224ee11e3fe_427c57f270" tabindex="-1" value="">
+      </div>
 
       <div class="clear">
         <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button">

--- a/pages/standard/guides/gov-au-guides.md
+++ b/pages/standard/guides/gov-au-guides.md
@@ -35,7 +35,7 @@ Style guidance and examples to help writers and editors create simpler, clearer,
 
 ## Where to go while the GOV.AU Guides are being developed
 
-### Content
+### Content {#content-links}
 
 - [Online writing style guide](https://www.dta.gov.au/standard/design-guides/online-writing/)
 - [Making content accessible](https://www.dta.gov.au/standard/design-guides/making-content-accessible/)

--- a/pages/talent.html
+++ b/pages/talent.html
@@ -2,6 +2,7 @@
 permalink: /talent/
 redirect_to_url: "https://ausdto.recruiterbox.com/jobs/b22434df78624c4a9751b19445e25d9b"
 exclude_from_search: true
+sitemap: false
 ---
 <!DOCTYPE html>
 <html lang="en-US">


### PR DESCRIPTION
Adds [pa11y-ci](https://github.com/pa11y/ci) to `citest.sh`.

CI starts up a background webserver in `ciserve.sh` for pa11y-ci to test against.

The existing `/sitemap.xml` created by jekyll-sitemap contains all the pdfs in the site, however pa11y-ci [raises an error](https://github.com/pa11y/ci/issues/10) when checking these. To solve this I have added a `/pa11y-sitemap.xml` which is just used by pa11y. When this issue is fixed in pa11y-ci this should be removed.

Have also fixed all the issues identified by pa11y so that the tests pass.

Closes #129
