### PR TITLE
Change post list on home page

### DIFF
--- a/_assets/scss/partials/_homepage.scss
+++ b/_assets/scss/partials/_homepage.scss
@@ -1,6 +1,8 @@
 .home-heading {
-  border-bottom: 6px solid $light-aqua;
-  padding-bottom: $tiny-spacing;
+  @include media($tablet) {
+    border-bottom: 6px solid $light-aqua;
+    padding-bottom: $tiny-spacing;
+  }
 }
 
 // Test to check if this can be removed post uikit 1.9.1/1.10.
@@ -11,6 +13,32 @@
   }
 }
 
+.news-media {
+  @include media($tablet) {
+    li:nth-child(-n+2) {
+      border-top: none;
+      padding-top: 0;
+    }
+  }
+
+  @include media($desktop) {
+    li:nth-child(-n+4) {
+      border-top: none;
+      padding-top: 0;
+    }
+  }
+
+  div.meta {
+    display: inline-block;
+    padding-top: $small-spacing;
+    time {
+      display: inline-block;
+    }
+    .tags {
+      margin-left: $tiny-spacing;
+    }
+  }
+}
 .what-we-do {
   .list-vertical--thirds {
 

--- a/_assets/scss/partials/_homepage.scss
+++ b/_assets/scss/partials/_homepage.scss
@@ -13,7 +13,7 @@
   }
 }
 
-.news-media {
+.news-media, .what-we-do {
   @include media($tablet) {
     li:nth-child(-n+2) {
       border-top: none;
@@ -39,17 +39,16 @@
     }
   }
 }
-.what-we-do {
-  .list-vertical--thirds {
 
+.what-we-do {
+  @include media($desktop) {
     li {
-      border-top: none;
-      border-left: solid 1px $grey;
+      min-height: 10em;
+      border-left: solid 1px $light-grey;
       padding: $small-spacing 0 $small-spacing $base-spacing;
       margin-bottom: $base-spacing;
-
-      p {
-        margin-bottom: 0;
+      &:first-child {
+        border-left: none;
       }
     }
   }
@@ -57,7 +56,7 @@
 
 // Shouldn't be necessary due to uikit's _grid-settings L#98 -- test after uikit 1.9.1/1.10.
 main {
-    @include ie-clearfix;
+  @include ie-clearfix;
 }
 
 // Test why the ie mixin doesn't suffice and that we have to use selectivizr's classes.
@@ -72,7 +71,6 @@ main {
 .lt-ie9 .homepage-footer {
   @include ie-clearfix; //FIXME! Blurg. Report to UI-Kit
 }
-
 
 .homepage-footer {
   @include outer-container;

--- a/_includes/breadcrumb.html
+++ b/_includes/breadcrumb.html
@@ -13,11 +13,6 @@
 <li><a href="/news/">News</a></li>
   {% endif %}
   {% endcapture %}
-{% elsif page.layout == 'media-release' %}
-  {% capture lis%}
-<li><a href="/news/">News</a></li>
-<li><a href="/news/media-releases/">Media releases</a></li>
-  {% endcapture %}
 {% endif %}
 
 {% if lis %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -6,18 +6,19 @@ layout: base
 
   <header class="about-dta">
     <h1>Digital Transformation Agency</h1>
-    <p class="abstract">The Digital Transformation Agency exists to make it easy for people to deal with government, by helping government transform services to be simple, clear and fast.</p>
+    <p class="abstract">The Digital Transformation Agency exists to make it easy for people to deal with government, by
+      helping government transform services to be simple, clear and fast.</p>
   </header>
 
   <section class="news-media">
-    <h2 class="home-heading">News and media</h2>
-    <ul class="list-vertical--fourths no-border">
+    <h2 class="home-heading">Latest news and blog posts</h2>
+    <ul class="list-vertical--fourths">
 
       {% for post in site.posts limit:8 %}
-      {% assign url = post.url %}
-      {% if post.external-url %}
-        {% assign url = post.external-url%}
-      {% endif %}
+        {% assign url = post.url %}
+        {% if post.external-url %}
+          {% assign url = post.external-url%}
+        {% endif %}
 
       <li>
         <figure>
@@ -33,34 +34,36 @@ layout: base
           </h3>
           <div class="meta">
             <time datetime="{{ post.date }}">{{ post.date | date: "%-d %b %Y" }}</time>
-            {% if post.category contains 'media-release' %}
-            <span>Media Release</span>
-            {% else %}
-            {{ post.author }}
-            {% endif %}
+            <span class="tags">
+              {% if post.category contains "blog" %}
+              <a href="/blog/">Blog</a>
+              {% else %}
+              <a href="/news/">News</a>
+              {% endif %}
+            </span>
           </div>
         </article>
       </li>
       {% endfor %}
     </ul>
-
-    <a class="see-more" href="/news/">See more news</a>
+    <p><a class="see-more" href="/news/">See more news</a></p>
+    <p><a class="see-more" href="/blog/">See more blog posts</a></p>
   </section>
 
   <section class="what-we-do">
     <h2 class="home-heading">What we&rsquo;re involved in</h2>
     <ul class="list-vertical--thirds">
 
-    {% for item in site.data.homepage_items %}
-    <li>
-      <article>
-        <h3>
-          <a href="{{ item.url }}">{{ item.title }}</a>
-        </h3>
-        <p>{{ item.description }}</p>
-      </article>
-    </li>
-    {% endfor %}
+      {% for item in site.data.homepage_items %}
+      <li>
+        <article>
+          <h3>
+            <a href="{{ item.url }}">{{ item.title }}</a>
+          </h3>
+          <p>{{ item.description }}</p>
+        </article>
+      </li>
+      {% endfor %}
     </ul>
   </section>
 
@@ -70,7 +73,7 @@ layout: base
       <h2 class="home-heading">Leadership</h2>
       <ul class="list-horizontal">
 
-      {% for leader in site.leadership-group %}
+        {% for leader in site.leadership-group %}
         <li>
           <figure>
             <img src="{{ leader.image | asset_path }}" alt="Image of {{ leader.title }}">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -52,7 +52,7 @@ layout: base
 
   <section class="what-we-do">
     <h2 class="home-heading">What we&rsquo;re involved in</h2>
-    <ul class="list-vertical--thirds">
+    <ul class="list-vertical--fourths">
 
       {% for item in site.data.homepage_items %}
       <li>

--- a/pages/blog/index.html
+++ b/pages/blog/index.html
@@ -6,13 +6,12 @@ searchexcerpt: Read the latest blog posts from the Digital Transformation Agency
 permalink: /blog/
 ---
 
-<article  id="content" class="content-main">
+<article  id="content" class="content-main latest-blog-posts">
 
   <h1>Blog</h1>
   <h2>Latest blog posts</h2>
 
-  <ul class="list-vertical no-border">
-
+  <ul class="list-vertical">
     {% for post in site.categories['blog'] limit:4 %}
     <li>
       <figure>


### PR DESCRIPTION
Removes Author's names, and adds blog/news tag under each post.
Also fixes a bug with the display of li separators.

Closes  #168 
Closes #93