### PR TITLE
Add timeout while waiting for webserver to start

### DIFF
--- a/bin/ciprepare.sh
+++ b/bin/ciprepare.sh
@@ -23,4 +23,3 @@ sudo apt-get update
 sudo apt-get install -qy apache2-utils
 
 npm install pa11y-ci@^0.4
-

--- a/bin/ciserve.sh
+++ b/bin/ciserve.sh
@@ -15,4 +15,4 @@ if [ -z "$TMPDIR" ]; then
 fi
 
 # Start a local copy of the site to test against
-bundle exec jekyll serve --destination $TMPDIR/_pa11y_site  >> _site/_serve_output.txt 2>&1
+bundle exec jekyll serve --destination $TMPDIR/_pa11y_site

--- a/bin/ciserve.sh
+++ b/bin/ciserve.sh
@@ -15,4 +15,4 @@ if [ -z "$TMPDIR" ]; then
 fi
 
 # Start a local copy of the site to test against
-bundle exec jekyll serve --destination $TMPDIR/_pa11y_site
+bundle exec jekyll serve --destination $TMPDIR/_pa11y_site  >> _site/_serve_output.txt 2>&1

--- a/bin/citest.sh
+++ b/bin/citest.sh
@@ -29,7 +29,7 @@ bundle exec htmlproofer _site  \
 echo "Waiting for webserver to start..."
 COUNT=0
 until $(curl --output /dev/null --silent --head --fail http://localhost:4000); do
-    COUNT=$(($COUNT+1))
+    ((COUNT++))
     if [ "$COUNT" -gt 24 ]
     then
         echo "Webserver did not start"

--- a/bin/citest.sh
+++ b/bin/citest.sh
@@ -4,12 +4,6 @@
 # EXPECTS THE SITE TO HAVE ALREADY BEEN BUILT AND RUNNING LOCALLY
 #
 
-echo "Waiting for webserver to start..."
-until $(curl --output /dev/null --silent --head --fail http://localhost:4000); do
-    sleep 5
-done
-echo "Webserver has started"
-
 # Exit immediately if there is an error
 set -e
 
@@ -18,9 +12,6 @@ set -o pipefail
 
 # echo out each line of the shell as it executes
 set -x
-
-#Run pa11y accessibility tests against the local running copy
-node_modules/.bin/pa11y-ci --sitemap http://localhost:4000/pa11y-sitemap.xml
 
 # Run jekyll hyde
 # Note - this will clobber the sitemap.xml using the site.url, so we just use production's
@@ -35,3 +26,18 @@ bundle exec htmlproofer _site  \
     --file-ignore /.*feed/index\.html/ \
     --empty-alt-ignore
 
+echo "Waiting for webserver to start..."
+COUNT=0
+until $(curl --output /dev/null --silent --head --fail http://localhost:4000); do
+    COUNT=$(($COUNT+1))
+    if [ "$COUNT" -gt 24 ]
+    then
+        echo "Webserver did not start"
+        exit 1
+    fi
+    sleep 5
+done
+echo "Webserver has started"
+
+#Run pa11y accessibility tests against the local running copy
+node_modules/.bin/pa11y-ci --sitemap http://localhost:4000/pa11y-sitemap.xml


### PR DESCRIPTION
In `citest.sh` I wanted to run htmlproofer before pa11y, as it is faster and so will find the things most likely to break sooner.

pa11y requires the webserver to be running before it starts. This is started in the background in parallel by circleci. I have moved the wait for the webserver later in the script as well so we're not waiting while we can do other work. We are using `set -x` (echo each line of the script), so this now means that every time we sleep a line is printed, which breaks [circleci timeouts](https://circleci.com/docs/configuration/#modifiers). Hence I've had to add a timeout.

I've done this with a simple loop counter. 