### PR TITLE
Change logo to svg with ie8 fallback to png

### DIFF
--- a/_assets/scss/partials/_header.scss
+++ b/_assets/scss/partials/_header.scss
@@ -1,4 +1,10 @@
-
+.lt-ie9 {
+  .page-header {
+    &__logo {
+      background-image: url('images/logo_dta_inline.png');
+    }
+  }
+}
 .page-header {
   a.logo {
     width: 523px;
@@ -6,11 +12,6 @@
   }
   &__logo {
     background-image: url('images/logo_dta_inline.svg');
-
-    @include ie-lte(8) {
-      background-image: url('images/logo_dta_inline.png');
-    }
-
     background-size: 100%;
     background-repeat: no-repeat;
     width: 523px;

--- a/_assets/scss/partials/_header.scss
+++ b/_assets/scss/partials/_header.scss
@@ -5,7 +5,11 @@
     height: 130px;
   }
   &__logo {
-    background: url('images/logo_dta_inline.png');
+    background-image: url('images/logo_dta_inline.svg');
+
+    @include ie-lte(8) {
+      background-image: url('images/logo_dta_inline.png');
+    }
 
     background-size: 100%;
     background-repeat: no-repeat;
@@ -21,7 +25,8 @@
 
     @include media($mobile-only) {
       margin-bottom: 0;
-      width: 320px;
+      width: 100%;
+      max-width: 400px;
     }
 
     @include media($tablet) {


### PR DESCRIPTION
When the site was being released, at the last minute I was having issues with the svg logo falling back to png for ie 8, so as a quick fix I changed to always use the png. This PR restores the svg logo for all browsers except for < ie 9 using the lt-ie9 class. I have tested that the png fallback works ok in ie8.
Closes #178