### PR TITLE
Change to jekyll-assets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'jekyll', '3.3.0'
 gem 'jekyll-assets'
 gem 'jekyll-redirect-from'
 gem 'jekyll-sitemap'
+gem 'jekyll-archives'
 
 gem 'therubyracer'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       pathutil (~> 0.9)
       rouge (~> 1.7)
       safe_yaml (~> 1.0)
+    jekyll-archives (2.1.1)
+      jekyll (>= 2.4)
     jekyll-assets (2.2.8)
       extras (~> 0.1)
       fastimage (~> 2.0, >= 1.8)
@@ -107,6 +109,7 @@ DEPENDENCIES
   font-awesome-sass
   html-proofer
   jekyll (= 3.3.0)
+  jekyll-archives
   jekyll-assets
   jekyll-redirect-from
   jekyll-sitemap

--- a/_assets/scss/partials/_blog.scss
+++ b/_assets/scss/partials/_blog.scss
@@ -10,6 +10,38 @@
   .post-meta {
     margin-bottom: $base-spacing * 1.25;
   }
+  .tags {
+    // Copy-pasta'd from UI-Kit
+    @include link-colours($button-bg-colour, $link-colour--hover, $link-colour);
+    color: $grey;
+
+    dl,
+    dt,
+    dd {
+      display: inline-block;
+      margin: 0;
+      padding: 0;
+      line-height: $base-heading-leading * 1.5; // Revisit.
+    }
+
+    dt,
+    dd {
+      margin-right: $tiny-spacing;
+      font-size: $small-font-size;
+    }
+
+    a {
+      padding: 2px $tiny-spacing;
+      border: 1px solid $button-bg-colour;
+      border-radius: 2px;
+
+      &:hover,
+      &:focus {
+        border-color: $link-colour--hover;
+      }
+    }
+
+  }
   h1,
   p,
   img {
@@ -80,3 +112,9 @@
     @include link-colours($non-black, $light-aqua, $non-black);
   }
 }
+
+// refactor this with homepage styles
+span.tags {
+  margin-left: $tiny-spacing;
+}
+

--- a/_assets/scss/partials/_homepage.scss
+++ b/_assets/scss/partials/_homepage.scss
@@ -34,7 +34,7 @@
     time {
       display: inline-block;
     }
-    .tags {
+    span a {
       margin-left: $tiny-spacing;
     }
   }

--- a/_assets/scss/partials/_homepage.scss
+++ b/_assets/scss/partials/_homepage.scss
@@ -34,7 +34,7 @@
     time {
       display: inline-block;
     }
-    span a {
+    a {
       margin-left: $tiny-spacing;
     }
   }

--- a/_config.yml
+++ b/_config.yml
@@ -8,8 +8,8 @@ url: "http://localhost:4000" # the base hostname & protocol for your site, e.g. 
 permalink: "/:categories/:title/"
 timezone: Australia/Canberra
 twitter: DTA
-
 google_tag_manager: GTM-KR7JDF
+tag_dir: tags # for tags pages created by jekyll-archives
 
 # Because there is no way to instantiate an empty array, and we need to merge two filtered
 # collections together -- this is used on the News page layout.
@@ -34,6 +34,8 @@ gems:
   - jekyll-assets
   - jekyll-redirect-from
   - jekyll-sitemap
+  - jekyll-archives
+
 
 exclude:
   - .asset-cache
@@ -62,6 +64,14 @@ assets:
 
   cache: .asset-cache
   prefix: "/"
+
+jekyll-archives:
+  enabled:
+    - 'tags'
+  layout: tag-archive
+  permalinks:
+    tag: '/tags/:name/'
+
 
 defaults:
   -

--- a/_includes/breadcrumb.html
+++ b/_includes/breadcrumb.html
@@ -15,27 +15,23 @@
   {% endcapture %}
 {% endif %}
 
-{% if lis %}
-
 <div class="global-breadcrumb">
   <nav class="breadcrumbs" aria-label="breadcrumb">
     <div class="wrapper">
       <ul>
         <li><a href="{{ site.baseurl }}/">Home</a></li>
+
+{% if lis %}
         {{ lis }}
         <li>{{ page.title}}</li>
-      </ul>
 
-    </div>
-  </nav>
-</div>
+{% elsif page.layout == 'tag-archive' %}
+        <li><a href="{{ site.tag_dir }}/">Tags</a></li>
+        {% unless page.url == "/{{site.tag_dir}}/}} %}
+        <li>{{ page.title}}</li>
+        {% endunless %}
+
 {% elsif page.breadcrumb_type == !nil and page.author == !nil %}
-<div class="global-breadcrumb">
-  <nav class="breadcrumbs" aria-label="breadcrumb">
-    <div class="wrapper">
-      <ul>
-
-        <li><a href="{{ site.baseurl }}/">Home</a></li>
   {% capture page_url_without_index_html %}{{ page.url | remove: "/index.html" }}{% endcapture %}
   {% assign splitted_url_parts = page_url_without_index_html | split: '/' %}
 
@@ -75,8 +71,9 @@
     {% assign label = page.breadcrumb %}
   {% endif %}
         <li>{{ label }}</li>
+{% endif %}
+
       </ul>
     </div>
   </nav>
 </div>
-{% endif %}

--- a/_includes/breadcrumb.html
+++ b/_includes/breadcrumb.html
@@ -26,7 +26,7 @@
         <li>{{ page.title}}</li>
 
 {% elsif page.layout == 'tag-archive' %}
-        <li><a href="{{ site.tag_dir }}/">Tags</a></li>
+        <li><a href="/{{ site.tag_dir }}/">Tags</a></li>
         {% unless page.url == "/{{site.tag_dir}}/}} %}
         <li>{{ page.title}}</li>
         {% endunless %}

--- a/_includes/breadcrumb.html
+++ b/_includes/breadcrumb.html
@@ -2,13 +2,6 @@
   {% capture lis%}
   {% if page.category contains 'blog' %}
 <li><a href="/blog/">Blog</a></li>
-    {% if page.tags %}
-      {% if page.tags[0] == 'gov.au' %}
-<li><a href="/blog/gov-au/">GOV.AU Blog</a></li>
-      {% elsif page.tags[0] == 'dto-news' %}
-<li><a href="/blog/dto-news/">DTO News</a></li>
-      {% endif %}
-    {% endif %}
   {% else %}
 <li><a href="/news/">News</a></li>
   {% endif %}

--- a/_includes/breadcrumb.html
+++ b/_includes/breadcrumb.html
@@ -18,14 +18,6 @@
         {{ lis }}
         <li>{{ page.title}}</li>
 
-{% elsif page.layout == 'tag-archive' %}
-        {% if page.url == "/tags/" %}
-        <li>Tags</li>
-        {% else %}
-        <li><a href="/{{ site.tag_dir }}/">Tags</a></li>
-        <li>{{ page.title}}</li>
-        {% endif %}
-
 {% elsif page.breadcrumb_type == !nil and page.author == !nil %}
   {% capture page_url_without_index_html %}{{ page.url | remove: "/index.html" }}{% endcapture %}
   {% assign splitted_url_parts = page_url_without_index_html | split: '/' %}

--- a/_includes/breadcrumb.html
+++ b/_includes/breadcrumb.html
@@ -26,10 +26,12 @@
         <li>{{ page.title}}</li>
 
 {% elsif page.layout == 'tag-archive' %}
+        {% if page.url == "/tags/" %}
+        <li>Tags</li>
+        {% else %}
         <li><a href="/{{ site.tag_dir }}/">Tags</a></li>
-        {% unless page.url == "/{{site.tag_dir}}/}} %}
         <li>{{ page.title}}</li>
-        {% endunless %}
+        {% endif %}
 
 {% elsif page.breadcrumb_type == !nil and page.author == !nil %}
   {% capture page_url_without_index_html %}{{ page.url | remove: "/index.html" }}{% endcapture %}

--- a/_includes/post-list-item.html
+++ b/_includes/post-list-item.html
@@ -30,9 +30,10 @@
     <dl>
       <dt>Tags:</dt>
       {% for tag in post.tags %}
+      {% if tag != '' %}
       <dd><a href="{{ site.baseurl }}/{{ site.tag_dir }}/{{ tag | slugify }}">{{ tag }}</a></dd>
+      {% endif %}
       {% endfor %}
     </dl>
   </footer>
-
 </article>

--- a/_includes/post-list-item.html
+++ b/_includes/post-list-item.html
@@ -26,7 +26,6 @@
 {% else %}
   <p>{{ post.content | strip_html | truncatewords:50}}</p>
 {% endif %}
-{% if include.show-tags %}
   <footer class="tags">
     <dl>
       <dt>Tags:</dt>
@@ -35,5 +34,5 @@
       {% endfor %}
     </dl>
   </footer>
-{% endif %}
+
 </article>

--- a/_includes/post-list-item.html
+++ b/_includes/post-list-item.html
@@ -31,7 +31,7 @@
       <dt>Tags:</dt>
       {% for tag in post.tags %}
       {% if tag != '' %}
-      <dd><a href="{{ site.baseurl }}/{{ site.tag_dir }}/{{ tag | slugify }}">{{ tag }}</a></dd>
+      <dd><a href="/{{ site.tag_dir }}/{{ tag | slugify }}">{{ tag }}</a></dd>
       {% endif %}
       {% endfor %}
     </dl>

--- a/_includes/post-list-item.html
+++ b/_includes/post-list-item.html
@@ -31,7 +31,7 @@
       <dt>Tags:</dt>
       {% for tag in post.tags %}
       {% if tag != '' %}
-      <dd><a href="/{{ site.tag_dir }}/{{ tag | slugify }}">{{ tag }}</a></dd>
+      <dd><a href="/{{ site.tag_dir }}/{{ tag | slugify }}">{%if tag=="dto-news"%}dto news{%else%}{{tag}}{%endif%}</a></dd>
       {% endif %}
       {% endfor %}
     </dl>

--- a/_includes/post-list-item.html
+++ b/_includes/post-list-item.html
@@ -26,6 +26,7 @@
 {% else %}
   <p>{{ post.content | strip_html | truncatewords:50}}</p>
 {% endif %}
+{% if post.tags.size > 0 %}
   <footer class="tags">
     <dl>
       <dt>Tags:</dt>
@@ -36,4 +37,5 @@
       {% endfor %}
     </dl>
   </footer>
+{% endif %}
 </article>

--- a/_includes/post-list-item.html
+++ b/_includes/post-list-item.html
@@ -26,4 +26,14 @@
 {% else %}
   <p>{{ post.content | strip_html | truncatewords:50}}</p>
 {% endif %}
+{% if include.show-tags %}
+  <footer class="tags">
+    <dl>
+      <dt>Tags:</dt>
+      {% for tag in post.tags %}
+      <dd><a href="{{ site.baseurl }}/{{ site.tag_dir }}/{{ tag | slugify }}">{{ tag }}</a></dd>
+      {% endfor %}
+    </dl>
+  </footer>
+{% endif %}
 </article>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -34,12 +34,11 @@ layout: base
           </h3>
           <div class="meta">
             <time datetime="{{ post.date }}">{{ post.date | date: "%-d %b %Y" }}</time>
-            <span class="tags">
-              {% if post.category contains "blog" %}
-              <a href="/blog/">Blog</a>
-              {% else %}
-              <a href="/news/">News</a>
-              {% endif %}
+            {% if post.category contains "blog" %}
+            <a href="/blog/">Blog</a>
+            {% else %}
+            <a href="/news/">News</a>
+            {% endif %}
             </span>
           </div>
         </article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,6 +13,7 @@ breadcrumb_type: post
     <h1 class="post-title">{{ page.title }}</h1>
     <div class="post-meta">
       <p>{% if blog %}{{ page.author }} &mdash; {% endif %}{{ page.date | date: "%b %-d, %Y" }}</p>
+      {% if page.tags.size > 0 %}
       <div class="tags">
         <dl>
           <dt>Tags:</dt>
@@ -23,6 +24,7 @@ breadcrumb_type: post
           {% endfor %}
         </dl>
       </div>
+      {% endif %}
     </div>
   </header>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -11,9 +11,19 @@ breadcrumb_type: post
 <article id="content" class="content-main">
   <header class="post-header">
     <h1 class="post-title">{{ page.title }}</h1>
-    <p class="post-meta">
-      {% if blog %}{{ page.author }} &mdash; {% endif %}{{ page.date | date: "%b %-d, %Y" }}
-    </p>
+    <div class="post-meta">
+      <p>{% if blog %}{{ page.author }} &mdash; {% endif %}{{ page.date | date: "%b %-d, %Y" }}</p>
+      <div class="tags">
+        <dl>
+          <dt>Tags:</dt>
+          {% for tag in page.tags %}
+          {% if tag != '' %}
+          <dd><a href="{{ site.baseurl }}/{{site.tag_dir}}/{{tag | slugify }}/" >{{tag}}</a></dd>
+          {% endif %}
+          {% endfor %}
+        </dl>
+      </div>
+    </div>
   </header>
 
   <div class="abstract">

--- a/_layouts/tag-archive.html
+++ b/_layouts/tag-archive.html
@@ -1,6 +1,7 @@
 ---
 layout: base
-header_border: true
+breadcrumb: "Tags"
+searchexcerpt: "Browse our posts by topic"
 ---
 
 <article  id="content" class="content-main">
@@ -8,11 +9,13 @@ header_border: true
 {% if page.url == "/tags/" %}
   <h1>Tags</h1>
 
-  <p>Click through to read our posts about the following topics:</p>
+  <p>Browse our posts by topics:</p>
 
   <div>
 
     <h1>{{ page.title }}</h1>
+
+    <ul class="list-small">
 
     {% capture site_tags %}{% for tag in site.tags %}{{ tag | first }}{% unless forloop.last %},{% endunless %}{% endfor %}{% endcapture %}
     <!-- {% assign tag_words = site_tags | split:',' | sort %} -->
@@ -34,30 +37,31 @@ header_border: true
 
     {% endcapture %}
 
-    <p>
-      <a href="{{ site.baseurl }}/tags/{{tag | slugify }}/" >{{tag}}</a>
-      — {{count}}
-    </p>
+    {% unless tag == '' %}
 
+
+      <li><a href="{{ site.baseurl }}/tags/{{tag | slugify }}/" >{{tag}}</a></li>
+
+
+    {% endunless %}
 
     <!-- <p> {{ tag | size }} </p> -->
 
-
-
     {% endfor %}
+    </ul>
 
   </div>
 
 {% else %}
 
   {% assign numberof = page.posts | size %}
-  <h1>{{ numberof }} {% if numberof == 1 %}post{% else %}posts{% endif %} tagged {{ page.title }}</h1>
+  <h1>{{ numberof }} {% if numberof == 1 %}post{% else %}posts{% endif %} tagged '{{ page.title }}'</h1>
 
   <ul class="list-horizontal">
 
     {% for post in page.posts %}
     <li>
-      {% include post-list-item.html show-tags=true%}
+      {% include post-list-item.html %}
     </li>
     {% endfor %}
 

--- a/_layouts/tag-archive.html
+++ b/_layouts/tag-archive.html
@@ -18,7 +18,7 @@ searchexcerpt: "Browse our posts by topic"
       {% for tag in tag_words %}
 
       {% unless tag == '' %}
-      <li><a href="{{ site.baseurl }}/tags/{{ tag | slugify }}/">{{ tag }}</a></li>
+      <li><a href="{{ site.baseurl }}/tags/{{ tag | slugify }}/">{%if tag=="dto-news"%}dto news{%else%}{{tag}}{%endif%}</a></li>
       {% endunless %}
       {% endfor %}
     </ul>
@@ -27,7 +27,7 @@ searchexcerpt: "Browse our posts by topic"
   {% else %}
 
   {% assign numberof = page.posts | size %}
-  <h1>{{ numberof }} {% if numberof == 1 %}post{% else %}posts{% endif %} tagged '{{ page.title }}'</h1>
+  <h1>{{ numberof }} {% if numberof == 1 %}post{% else %}posts{% endif %} tagged '{%if page.title=="dto-news"%}dto news{%else%}{{page.title}}{%endif%}'</h1>
   {% if page.title == "dto-news" %}
   <p>Archived news from the Digital Transformation Office.</p>
   {% endif %}

--- a/_layouts/tag-archive.html
+++ b/_layouts/tag-archive.html
@@ -4,55 +4,43 @@ breadcrumb: "Tags"
 searchexcerpt: "Browse our posts by topic"
 ---
 
-<article  id="content" class="content-main">
-
-{% if page.url == "/tags/" %}
+<article id="content" class="content-main">
+  {% if page.url == "/tags/" %}
   <h1>Tags</h1>
-
   <p>Browse our posts by topics:</p>
-
   <div>
-
-    <h1>{{ page.title }}</h1>
-
     <ul class="list-small">
 
-    {% capture site_tags %}{% for tag in site.tags %}{{ tag | first }}{% unless forloop.last %},{% endunless %}{% endfor %}{% endcapture %}
-    <!-- {% assign tag_words = site_tags | split:',' | sort %} -->
+      {% capture site_tags %}{% for tag in site.tags %}{{ tag | first }}{% unless forloop.last %},{% endunless %}{%
+      endfor %}{% endcapture %}
+      {% assign tag_words = site_tags | split:',' | sort %}
 
-    {% for tag in tag_words %}
+      {% for tag in tag_words %}
 
-    {% capture count %}
+      {% capture count %}
 
-    {% for tag_number in site.tags %}
+      {% for tag_number in site.tags %}
 
-    {% if tag_number[0] == tag %}
+      {% if tag_number[0] == tag %}
 
-    {{tag_number[1] | size }}
-    <!-- <p> {{tag | size }} </p> -->
+      {{tag_number[1] | size }}
 
-    {% endif %}
+      {% endif %}
 
-    {% endfor %}
+      {% endfor %}
 
-    {% endcapture %}
+      {% endcapture %}
 
-    {% unless tag == '' %}
+      {% unless tag == '' %}
 
+      <li><a href="{{ site.baseurl }}/tags/{{tag | slugify }}/">{{tag}}</a></li>
 
-      <li><a href="{{ site.baseurl }}/tags/{{tag | slugify }}/" >{{tag}}</a></li>
-
-
-    {% endunless %}
-
-    <!-- <p> {{ tag | size }} </p> -->
-
-    {% endfor %}
+      {% endunless %}
+      {% endfor %}
     </ul>
 
   </div>
-
-{% else %}
+  {% else %}
 
   {% assign numberof = page.posts | size %}
   <h1>{{ numberof }} {% if numberof == 1 %}post{% else %}posts{% endif %} tagged '{{ page.title }}'</h1>
@@ -66,7 +54,7 @@ searchexcerpt: "Browse our posts by topic"
     {% endfor %}
 
   </ul>
-{% endif %}
+  {% endif %}
 </article>
 
 

--- a/_layouts/tag-archive.html
+++ b/_layouts/tag-archive.html
@@ -44,7 +44,9 @@ searchexcerpt: "Browse our posts by topic"
 
   {% assign numberof = page.posts | size %}
   <h1>{{ numberof }} {% if numberof == 1 %}post{% else %}posts{% endif %} tagged '{{ page.title }}'</h1>
-
+  {% if page.title == "dto-news" %}
+  <p>Archived news from the Digital Transformation Office.</p>
+  {% endif %}
   <ul class="list-horizontal">
 
     {% for post in page.posts %}

--- a/_layouts/tag-archive.html
+++ b/_layouts/tag-archive.html
@@ -7,7 +7,7 @@ searchexcerpt: "Browse our posts by topic"
 <article id="content" class="content-main">
   {% if page.url == "/tags/" %}
   <h1>Tags</h1>
-  <p>Browse our posts by topics:</p>
+  <p>Browse our posts by topic:</p>
   <div>
     <ul class="list-small">
 
@@ -17,24 +17,8 @@ searchexcerpt: "Browse our posts by topic"
 
       {% for tag in tag_words %}
 
-      {% capture count %}
-
-      {% for tag_number in site.tags %}
-
-      {% if tag_number[0] == tag %}
-
-      {{tag_number[1] | size }}
-
-      {% endif %}
-
-      {% endfor %}
-
-      {% endcapture %}
-
       {% unless tag == '' %}
-
-      <li><a href="{{ site.baseurl }}/tags/{{tag | slugify }}/">{{tag}}</a></li>
-
+      <li><a href="{{ site.baseurl }}/tags/{{ tag | slugify }}/">{{ tag }}</a></li>
       {% endunless %}
       {% endfor %}
     </ul>

--- a/_layouts/tag-archive.html
+++ b/_layouts/tag-archive.html
@@ -1,0 +1,68 @@
+---
+layout: base
+header_border: true
+---
+
+<article  id="content" class="content-main">
+
+{% if page.url == "/tags/" %}
+  <h1>Tags</h1>
+
+  <p>Click through to read our posts about the following topics:</p>
+
+  <div>
+
+    <h1>{{ page.title }}</h1>
+
+    {% capture site_tags %}{% for tag in site.tags %}{{ tag | first }}{% unless forloop.last %},{% endunless %}{% endfor %}{% endcapture %}
+    <!-- {% assign tag_words = site_tags | split:',' | sort %} -->
+
+    {% for tag in tag_words %}
+
+    {% capture count %}
+
+    {% for tag_number in site.tags %}
+
+    {% if tag_number[0] == tag %}
+
+    {{tag_number[1] | size }}
+    <!-- <p> {{tag | size }} </p> -->
+
+    {% endif %}
+
+    {% endfor %}
+
+    {% endcapture %}
+
+    <p>
+      <a href="{{ site.baseurl }}/tags/{{tag | slugify }}/" >{{tag}}</a>
+      — {{count}}
+    </p>
+
+
+    <!-- <p> {{ tag | size }} </p> -->
+
+
+
+    {% endfor %}
+
+  </div>
+
+{% else %}
+
+  {% assign numberof = page.posts | size %}
+  <h1>{{ numberof }} {% if numberof == 1 %}post{% else %}posts{% endif %} tagged {{ page.title }}</h1>
+
+  <ul class="list-horizontal">
+
+    {% for post in page.posts %}
+    <li>
+      {% include post-list-item.html show-tags=true%}
+    </li>
+    {% endfor %}
+
+  </ul>
+{% endif %}
+</article>
+
+

--- a/_posts/2016-08-29-digital-marketplace-beta.md
+++ b/_posts/2016-08-29-digital-marketplace-beta.md
@@ -3,7 +3,7 @@ layout: post
 title: Digital Marketplace goes to Beta
 author: Catherine Thompson
 category: blog
-tag: [dto-news, marketplace]
+tag: [dto-news, "digital marketplace"]
 hero-image: /images/blog-content/marketplace-hero.jpg
 thumbnail: /images/blog-thumbnails/marketplace-thumb.jpg
 searchexcerpt: 

--- a/_posts/2016-10-21-marketplace-sharing-positive-feedback.md
+++ b/_posts/2016-10-21-marketplace-sharing-positive-feedback.md
@@ -2,7 +2,7 @@
 title: "Digital Marketplace: Sharing positive feedback from early adopters"
 author: Steven Berends
 category: blog
-tags: [dto-news,marketplace,dta-news]
+tags: [marketplace]
 hero-image: /images/blog-content/marketplace-laptop-hero.jpg
 thumbnail: /images/blog-thumbnails/marketplace-laptop-thumbnail.jpg
 ---

--- a/_posts/2016-10-21-marketplace-sharing-positive-feedback.md
+++ b/_posts/2016-10-21-marketplace-sharing-positive-feedback.md
@@ -2,7 +2,7 @@
 title: "Digital Marketplace: Sharing positive feedback from early adopters"
 author: Steven Berends
 category: blog
-tags: [marketplace]
+tags: [digital marketplace]
 hero-image: /images/blog-content/marketplace-laptop-hero.jpg
 thumbnail: /images/blog-thumbnails/marketplace-laptop-thumbnail.jpg
 ---

--- a/_posts/2016-10-28-new-digital-agency-establishes-agenda.md
+++ b/_posts/2016-10-28-new-digital-agency-establishes-agenda.md
@@ -3,7 +3,7 @@ layout: post
 title: "New Digital Agency establishes agenda"
 author: Hon Angus Taylor MP
 category: [news, media-release]
-tag:
+tag: [dta news]
 thumbnail: /images/blog-thumbnails/angus-taylor-thumb.jpg
 searchexcerpt: A new Digital Transformation Agency has been formally established to guide, oversee and drive the Government’s ambitious digital and ICT agendas. This follows approval this week by the Governor General of the Agency’s establishment and remit.
 external-url: http://ministers.dpmc.gov.au/taylor/2016/new-digital-agency-establishes-agenda

--- a/_posts/2016-11-09-marketplace-shaped-by-user-needs.md
+++ b/_posts/2016-11-09-marketplace-shaped-by-user-needs.md
@@ -4,7 +4,7 @@ title: "How the Digital Marketplace is being shaped by user needs"
 author: Robyn Prince Gillot
 author-excerpt: "Robyn Prince Gillot, is a researcher in the Digital Marketplace team, based in Sydney."
 category: blog
-tag: marketplace
+tag: "digital marketplace"
 hero-image: /images/blog-content/marketplace-user-needs-content.jpg
 thumbnail: /images/blog-thumbnails/marketplace-user-needs-thumb.jpg
 ---

--- a/_posts/2016-11-18-marketplace-roundtable.md
+++ b/_posts/2016-11-18-marketplace-roundtable.md
@@ -4,7 +4,7 @@ title: "Digital Marketplace: sharing ideas at the roundtable"
 author: Steven Berends
 author-excerpt: "Steven Berends is the Digital Marketplace content designer, based in Sydney."
 category: blog
-tag: marketplace
+tag: "digital marketplace"
 hero-image: /images/blog-content/mp-roundtable-image06.jpg
 thumbnail: /images/blog-thumbnails/mp-roundtable-thumb.jpg
 ---

--- a/_posts/2016-11-22-how-the-bom-put-users-needs-first.md
+++ b/_posts/2016-11-22-how-the-bom-put-users-needs-first.md
@@ -3,7 +3,6 @@ layout: post
 title: "How the BOM put users’ needs first"
 author: 'Jenny Hunter'
 category: blog
-tag: ''
 hero-image: /images/blog-content/bom-app-content.png
 thumbnail: /images/blog-thumbnails/bom-app-thumb.png
 ---

--- a/_posts/2016-11-30-paul-shetler-resignation.md
+++ b/_posts/2016-11-30-paul-shetler-resignation.md
@@ -2,7 +2,7 @@
 title: "Media Statement"
 category: [news, media-release]
 redirect_from: "/news/media-release/media-statement-paul-shetler-resignation/"
-tag: ''
+tag: 'dta news'
 thumbnail: /images/blog-thumbnails/dta-logo-thumb.png
 feed: true
 ---

--- a/_posts/2016-12-15-digital-steps-to-benefit-users.md
+++ b/_posts/2016-12-15-digital-steps-to-benefit-users.md
@@ -1,7 +1,7 @@
 ---
 title: "Digital steps to benefit users"
 category: [news]
-tag: 'transformation'
+tag: 'digital transformation'
 thumbnail: /images/blog-thumbnails/modernising-mygov-thumb.png
 hero-image: /images/blog-content/modernising-mygov-hero.png
 feed: true

--- a/bin/cibuild.sh
+++ b/bin/cibuild.sh
@@ -9,17 +9,20 @@ set -o pipefail
 # echo out each line of the shell as it executes
 set -x
 
+# Use JEKYLL_ENV to configure jekyll-assets
+export JEKYLL_ENV=production
+
 main() {
   readonly GITBRANCH="${CIRCLE_BRANCH}"
 
   case "${GITBRANCH}" in
     master)
       echo "Building with production jekyll config"
-      JEKYLL_ENV=production bundle exec jekyll build --config _config.yml,_config-production.yml
+      bundle exec jekyll build --config _config.yml,_config-production.yml
       ;;
     develop)
       echo "Building with development/staging jekyll config"
-      JEKYLL_ENV=production bundle exec jekyll build --config _config.yml,_config-develop.yml
+      bundle exec jekyll build --config _config.yml,_config-develop.yml
       ;;
     *)
       echo "Building with normal jekyll config"

--- a/pages/blog/dto-news/index.html
+++ b/pages/blog/dto-news/index.html
@@ -1,17 +1,4 @@
 ---
-layout: basic
-title: DTO News
-lede: Archived news from the Digital Transformation Office.
-searchexcerpt: Archived news from the Digital Transformation Office.
-permalink: /blog/dto-news/
+redirect_to: "/tags/dto-news"
 ---
 
-<ul class="list-horizontal">
-  {% for post in site.categories['blog'] %}
-    {% if post.tags contains 'dto-news' %}
-  <li>
-      {% include post-list-item.html %}
-  </li>
-    {% endif %}
-  {% endfor %}
-</ul>

--- a/pages/blog/dto-news/index.html
+++ b/pages/blog/dto-news/index.html
@@ -1,4 +1,4 @@
 ---
-redirect_to: "/tags/dto-news"
+permalink: /blog/dto-news/
+redirect_to: /tags/dto-news/
 ---
-

--- a/pages/blog/dto-news/index.html
+++ b/pages/blog/dto-news/index.html
@@ -1,4 +1,15 @@
 ---
 permalink: /blog/dto-news/
-redirect_to: /tags/dto-news/
+redirect_to_url: /tags/dto-news/
+exclude_from_search: true
+sitemap: false
 ---
+<!DOCTYPE html>
+<html lang="en-US">
+<meta charset="utf-8">
+<title>Redirecting…</title>
+<link rel="canonical" href="{{ page.redirect_to_url }}">
+<meta http-equiv="refresh" content="0; url={{ page.redirect_to_url }}">
+<a href="{{ page.redirect_to_url }}">Click here if you are not redirected.</a>
+<script>location = "{{ page.redirect_to_url }}"</script>
+</html>

--- a/pages/blog/gov-au-blog/index.html
+++ b/pages/blog/gov-au-blog/index.html
@@ -1,15 +1,4 @@
 ---
-layout: basic
-title: GOV.AU Blog
-permalink: /blog/gov-au/
+redirect_to: "/tags/gov-au/"
 ---
-<ul class="list-horizontal">
-  {% for post in site.categories['blog'] %}
-    {% if post.tags contains 'gov.au'  %}
-  <li>
-      {% include post-list-item.html %}
-  </li>
-    {% endif %}
-  {% endfor %}
-</ul>
 

--- a/pages/blog/gov-au-blog/index.html
+++ b/pages/blog/gov-au-blog/index.html
@@ -1,4 +1,4 @@
 ---
-redirect_to: "/tags/gov-au/"
+permalink: /blog/gov-au/
+redirect_to: /tags/gov-au/
 ---
-

--- a/pages/blog/gov-au-blog/index.html
+++ b/pages/blog/gov-au-blog/index.html
@@ -1,4 +1,16 @@
 ---
 permalink: /blog/gov-au/
-redirect_to: /tags/gov-au/
+redirect_to_url: /tags/gov-au/
+exclude_from_search: true
+sitemap: false
 ---
+<!DOCTYPE html>
+<html lang="en-US">
+<meta charset="utf-8">
+<title>Redirecting…</title>
+<link rel="canonical" href="{{ page.redirect_to_url }}">
+<meta http-equiv="refresh" content="0; url={{ page.redirect_to_url }}">
+<a href="{{ page.redirect_to_url }}">Click here if you are not redirected.</a>
+<script>location = "{{ page.redirect_to_url }}"</script>
+</html>
+

--- a/pages/blog/index.html
+++ b/pages/blog/index.html
@@ -60,7 +60,7 @@ permalink: /blog/
   {% for tag in tag_words %}
     {% unless tag == '' %}
     <li>
-      <a href="{{ site.baseurl }}/tags/{{tag | slugify }}/" >{{tag}}</a>
+      <a href="{{ site.baseurl }}/tags/{{tag | slugify }}/">{%if tag=="dto-news"%}dto news{%else%}{{tag}}{%endif%}</a>
 
     </li>
     {%endunless%}

--- a/pages/blog/index.html
+++ b/pages/blog/index.html
@@ -32,7 +32,7 @@ permalink: /blog/
 
           </span>
         </div>
-        {% if post.tags %}
+        {% if post.tags.size > 0 %}
         <footer class="tags">
           <dl>
             <dt>Tags:</dt>

--- a/pages/blog/index.html
+++ b/pages/blog/index.html
@@ -36,17 +36,23 @@ permalink: /blog/
 
   <a class="see-more" href="/blog/all-posts/">See all blog posts</a>
 
-  <h2>Blogs</h2>
+  <h2>Tags</h2>
+
+  {% capture site_tags %}{% for tag in site.tags %}{{ tag | first }}{% unless forloop.last %},{% endunless %}{% endfor %}{% endcapture %}
+  {% assign tag_words = site_tags | split:',' | sort %}
+
   <ul class="list-small">
+  {% for tag in tag_words %}
+    {% unless tag == '' %}
     <li>
-      <a href="/blog/gov-au/">GOV.AU blog</a>
-      <p>Read the latest news about the development of the GOV.AU project.</p>
+      <a href="{{ site.baseurl }}/tags/{{tag | slugify }}/" >{{tag}}</a>
+
     </li>
-    <li>
-      <a href="/blog/dto-news/">Archived DTO News</a>
-      <p>Read archived news from the Digital Transformation Office.</p>
-    </li>
+    {%endunless%}
+    {% endfor %}
   </ul>
+
+
 
 </article>
 

--- a/pages/blog/index.html
+++ b/pages/blog/index.html
@@ -29,13 +29,21 @@ permalink: /blog/
           <time datetime="{{ post.date }}">{{ post.date | date: "%-d %b %Y" }}</time>
           {{ post.author }}
           <span class="tags">
-          {% for tag in post.tags %}
-            {% if tag != '' %}
-            <a href="/{{site.tag_dir}}/{{tag | slugify }}/" >{{tag}}</a>
-            {% endif %}
-          {% endfor %}
+
           </span>
         </div>
+        {% if post.tags %}
+        <footer class="tags">
+          <dl>
+            <dt>Tags:</dt>
+            {% for tag in post.tags %}
+            {% if tag != '' %}
+            <dd><a href="/{{site.tag_dir}}/{{tag | slugify }}/" >{{tag}}</a></dd>
+            {% endif %}
+            {% endfor %}
+          </dl>
+        </footer>
+        {% endif %}
       </article>
     </li>
     {% endfor %}

--- a/pages/blog/index.html
+++ b/pages/blog/index.html
@@ -28,6 +28,13 @@ permalink: /blog/
         <div class="meta">
           <time datetime="{{ post.date }}">{{ post.date | date: "%-d %b %Y" }}</time>
           {{ post.author }}
+          <span class="tags">
+          {% for tag in post.tags %}
+            {% if tag != '' %}
+            <a href="/{{site.tag_dir}}/{{tag | slugify }}/" >{{tag}}</a>
+            {% endif %}
+          {% endfor %}
+          </span>
         </div>
       </article>
     </li>

--- a/pages/news/index.html
+++ b/pages/news/index.html
@@ -28,5 +28,5 @@ permalink: /news/
   <a class="see-all" href="/news/all/">See all news</a>
 </p>
 <p>
-<a class="see-all" href="/blog/dto-news/">See previous DTO news</a>
+<a class="see-all" href="/{{ site.tag_dir }}/dto-news/">See previous DTO news</a>
 </p>

--- a/pages/tags.html
+++ b/pages/tags.html
@@ -1,0 +1,27 @@
+---
+layout: basic
+title: Tags
+searchexcerpt: "Browse our posts by tag"
+permalink: /tags/
+---
+
+<p>Browse our posts by tag:</p>
+
+<div>
+  <ul class="list-small">
+
+    {% capture site_tags %}{% for tag in site.tags %}{{ tag | first }}{% unless forloop.last %},{% endunless %}{%
+    endfor %}{% endcapture %}
+    {% assign tag_words = site_tags | split:',' | sort %}
+
+    {% for tag in tag_words %}
+
+    {% unless tag == '' %}
+    <li><a href="{{ site.baseurl }}/tags/{{ tag | slugify }}/">{%if tag=="dto-news"%}dto news{%else%}{{tag}}{%endif%}</a></li>
+    {% endunless %}
+    {% endfor %}
+  </ul>
+
+</div>
+
+

--- a/pages/what-we-do/transformation-agenda/transformation-agenda.md
+++ b/pages/what-we-do/transformation-agenda/transformation-agenda.md
@@ -165,13 +165,11 @@ Having problems seeing this image? [Open larger roadmap image](/what-we-do/trans
         </h3>
         <div class="meta">
           <time datetime="{{ post.date }}">{{ post.date | date: "%-d %b %Y" }}</time>
-          <span class="tags">
-            {% if post.category contains "blog" %}
-            <a href="/blog/">Blog</a>
-            {% else %}
-            <a href="/news/">News</a>
-            {% endif %}
-          </span>
+          {% if post.category contains "blog" %}
+          <a href="/blog/">Blog</a>
+          {% else %}
+          <a href="/news/">News</a>
+          {% endif %}
         </div>
       </article>
   </li>


### PR DESCRIPTION
- Change from the manually created pages for each tag to [jekyll-assets](https://github.com/jekyll/jekyll-assets) so it is easier to manage tags.
- Tags are now visible on the post list pages and when viewing the post.