### PR TITLE
Change assessment reports list from tabs to inline-links

### DIFF
--- a/_assets/js/assessment-tabs.js
+++ b/_assets/js/assessment-tabs.js
@@ -1,10 +1,10 @@
 
 $(document).ready(function(){
 
-	$('nav.inline-tab-nav ul li a').click(function(){
+	$('.assessment-reports ul li a').click(function(){
 		var tab_id = $(this).attr('href');
 
-		$('nav.inline-tab-nav ul li a').removeClass('is-current');
+		$('.assessment-reports ul li a').removeClass('is-current');
 		$('.tab-pane').removeClass('active');
 
 		$(this).addClass('is-current');

--- a/_assets/scss/partials/_assessment-reports.scss
+++ b/_assets/scss/partials/_assessment-reports.scss
@@ -27,78 +27,72 @@ ul {
   }
 }
 
-//list of assessment reports
-.assessment-list-header {
-  height: 0;
-  margin: 40px 0 10px;
-  font-size: 17px;
-  .inner {
-    display: inline-block;
-    background-color: #fff;
-    top: -13px;
-    position: relative;
-    font-weight: 600;
-  }
-}
+.assessment-reports {
 
-.assessment-list-header-v2 {
-  border-bottom: 1px solid $dta-light-grey;
-  height: 0;
-  margin: 60px 0 10px;
-  font-size: 17px;
-  text-align: center;
-  .inner {
-    display: inline-block;
-    background-color: #fff;
-    top: -13px;
-    position: relative;
-    font-weight: 600;
+  .inline-links a.is-current {
+    color: $dark-aqua;
+    font-weight: bold;
+    background-color: $lighter-aqua;
   }
-}
 
-.assessment-report-list {
-  margin-top: 40px;
-  list-style-type: none;
-  padding-left: 0;
-  li {
-    margin-bottom: 20px;
-    padding-bottom: 20px;
-    border-bottom: 1px solid $dta-light-grey;
-  }
-  .Beta, .Alpha, .Live {
-    float: left;
-    margin-right: 13px;
-    min-width: 65px;
-    padding: 2px;
-    font-size: 18px;
-    font-weight: 600;
-    color: #fff;
-    text-align: center;
-    border-radius: 6px;
-    @media (max-width: $mobile-minwidth) {
-      float: right;
-      padding: 2px 5px;
-    }
-  }
-  .Beta {
-    background-color: $beta;
-  }
-  .Alpha {
-    background-color: $alpha;
-  }
-  a {
-    font-weight: 600;
-    margin-right: 6px;
-    font-size: 18px;
-    text-decoration: none;
-    @media (max-width: $mobile-minwidth) {
-      display: block;
-      margin-bottom: 8px;
-    }
-  }
-  .assessed-by, .date {
-    color: $dta-mid-grey;
+  //list of assessment reports
+  .assessment-list-header {
+    height: 0;
+    margin: 40px 0 10px;
     font-size: 17px;
+    .inner {
+      display: inline-block;
+      background-color: #fff;
+      top: -13px;
+      position: relative;
+      font-weight: 600;
+    }
+  }
+
+  .assessment-report-list {
+    margin-top: 40px;
+    list-style-type: none;
+    padding-left: 0;
+    li {
+      margin-bottom: 20px;
+      padding-bottom: 20px;
+      border-bottom: 1px solid $dta-light-grey;
+    }
+    .Beta, .Alpha, .Live {
+      float: left;
+      margin-right: 13px;
+      min-width: 65px;
+      padding: 2px;
+      font-size: 18px;
+      font-weight: 600;
+      color: #fff;
+      text-align: center;
+      border-radius: 6px;
+      @media (max-width: $mobile-minwidth) {
+        float: right;
+        padding: 2px 5px;
+      }
+    }
+    .Beta {
+      background-color: $beta;
+    }
+    .Alpha {
+      background-color: $alpha;
+    }
+    a {
+      font-weight: 600;
+      margin-right: 6px;
+      font-size: 18px;
+      text-decoration: none;
+      @media (max-width: $mobile-minwidth) {
+        display: block;
+        margin-bottom: 8px;
+      }
+    }
+    .assessed-by, .date {
+      color: $dta-mid-grey;
+      font-size: 17px;
+    }
   }
 }
 
@@ -109,25 +103,6 @@ ul {
     text-decoration-style: dotted;
     font-weight: 600;
     color: $dta-dark-grey;
-  }
-}
-
-//nav tabs
-.assessment-report-tabs {
-
-  @include media($mobile) {
-    li {
-      float: none;
-      &.active a {
-        background-color: $dta-background-grey;
-        border-radius: 0;
-        border: none;
-      }
-    }
-  }
-
-  li a {
-    font-size: 15px;
   }
 }
 

--- a/pages/standard/assessment-reports.md
+++ b/pages/standard/assessment-reports.md
@@ -5,51 +5,37 @@ permalink: /standard/assessments/
 breadcrumb: Assessment reports
 ---
 
-
+<div class="assessment-reports" markdown="1">
 
 All services in the [scope of the Digital Service Standard](/standard/scope-of-standard/) are [assessed against the Standard](/standard/meeting-standard/).
 
 We publish assessment reports to increase the transparency of government and help other teams build simpler, better and faster services for all users.
 
-<div>
+## View reports by
 
-  <!-- Nav tabs -->
-  <nav class="inline-tab-nav">
-    <h3>View by:</h3>
-    <ul role="tablist">
-      <li role="presentation">
-        <a href="#all" class="is-current" aria-controls="all" role="tab">
-          <span class="is-visuallyhidden">Show </span>All reports
-        </a>
-      </li>
-      <li role="presentation">
-        <a href="#dta-assessed" aria-controls="dta-assessed" role="tab">
-          <span class="is-visuallyhidden">Show only </span>DTA&ndash;led assessments
-        </a>
-      </li>
-      <li role="presentation">
-        <a href="#agency-assessed" aria-controls="agency-assessed" role="tab">
-          <span class="is-visuallyhidden">Show only </span>Self assessments
-        </a>
-      </li>
-      <li role="presentation">
-         <a href="#alpha-assessments" aria-controls="alpha" role="tab">
-           <span class="is-visuallyhidden">Show only </span>Alpha assessments
-         </a>
-      </li>
-      <li role="presentation">
-        <a href="#beta-assessments" aria-controls="beta" role="tab">
-          <span class="is-visuallyhidden">Show only </span>Beta assessments
-        </a>
-      </li>
-    </ul>
-  </nav>
+  <ul class="inline-links">
+    <li>
+      <a href="#all" class="is-current"><span class="is-visuallyhidden">Show </span>All reports</a>
+    </li>
+    <li>
+      <a href="#dta-assessed"><span class="is-visuallyhidden">Show only </span>DTA&ndash;led assessments</a>
+    </li>
+    <li>
+      <a href="#agency-assessed"><span class="is-visuallyhidden">Show only </span>Self assessments</a>
+    </li>
+    <li>
+      <a href="#alpha-assessments"><span class="is-visuallyhidden">Show only </span>Alpha assessments</a>
+    </li>
+    <li>
+      <a href="#beta-assessments"><span class="is-visuallyhidden">Show only </span>Beta assessments</a>
+    </li>
+  </ul>
 
   <!-- Tab panes -->
   <div class="tab-content">
 
     <div role="tabpanel" class="tab-pane active" id="all">
-    <h2 class="assessment-list-header"><span class="inner">All assessment reports</span></h2>
+      <h2 class="assessment-list-header"><span class="inner">All assessment reports</span></h2>
       {% include assessment-reports/assessment-reports-list.html %}
     </div>
 
@@ -73,8 +59,4 @@ We publish assessment reports to increase the transparency of government and hel
       {% include assessment-reports/assessment-reports-list-beta.html %}
     </div>
   </div>
-
 </div>
-
-
-


### PR DESCRIPTION
I suggest reviewing the [files changed ignoring whitespace ?w=1](https://github.com/AusDTO/dta-website/pull/251/files?w=1)

![image](https://cloud.githubusercontent.com/assets/2324569/21669172/70b69700-d35d-11e6-8036-73b20fd1b9de.png)

Closes #147 