### PR TITLE
Add event contact form

### DIFF
--- a/pages/contact/contact.md
+++ b/pages/contact/contact.md
@@ -42,7 +42,7 @@ If you have any questions about the Digital Marketplace, or if you would like to
 
 ## Events and media
 
-If you'd like someone from DTA to speak at an event, please send an email to [events@digital.gov.au](mailto:events@digital.gov.au).
+If you'd like someone from the DTA to speak at an event, [send us a speaking request](/contact/events/). Please make sure to complete all the questions.
 
 If you are a journalist and have a media enquiry, please send an email to [media@digital.gov.au](mailto:media@digital.gov.au).
 

--- a/pages/contact/events.html
+++ b/pages/contact/events.html
@@ -30,8 +30,8 @@ searchexcerpt: Fill in this form if you'd like someone from the DTA to speak at 
     <input required="required" type="text" id="event-title" name="event_title" value="" size="60" maxlength="128"/>
   </p>
   <p>
-    <label for="name">Name</label>
-    <input required="required" type="text" id="name" name="name" value="" size="60" maxlength="128"/>
+    <label for="contact-name">Contact name</label>
+    <input required="required" type="text" id="contact-name" name="contact_name" value="" size="60" maxlength="128"/>
   </p>
   <p>
     <label for="organisation">Organisation</label>

--- a/pages/contact/events.html
+++ b/pages/contact/events.html
@@ -6,7 +6,7 @@ permalink: /contact/events/
 searchexcerpt: Fill in this form if you'd like someone from the DTA to speak at an event.
 ---
 
-<form method="post" action="https://script.google.com/macros/s/AKfycbzxBPoL_AI5RR7LMgVmRKFQqUyD_FzKRPfKRKGTgC2SLB4NVzxf/exec">
+<form method="post" action="https://script.google.com/macros/s/AKfycbzxBPoL_AI5RR7LMgVmRKFQqUyD_FzKRPfKRKGTgC2SLB4NVzxf/exec{% if jekyll.environment == "development" %}?test=1{% endif %}">
   <p class="lead-in">A couple of things you need to know:</p>
   <ul>
     <li>We tend not to speak at events that charge APS members to attend.</li>

--- a/pages/contact/events.html
+++ b/pages/contact/events.html
@@ -1,0 +1,90 @@
+---
+layout: basic
+title: "I'd like someone from the DTA to speak at my event"
+breadcrumb: Event contact form
+permalink: /contact/events/
+searchexcerpt: Fill in this form if you'd like someone from the DTA to speak at an event.
+---
+
+<form method="post" action="https://script.google.com/macros/s/AKfycbzxBPoL_AI5RR7LMgVmRKFQqUyD_FzKRPfKRKGTgC2SLB4NVzxf/exec">
+  <p class="lead-in">A couple of things you need to know:</p>
+  <ul>
+    <li>We tend not to speak at events that charge APS members to attend.</li>
+    <li>We receive a large number of invitations and need to prioritise our resources. At the moment, we’re
+      particularly focused on events with attendees from the start-up/entrepreneurial sector.
+    </li>
+  </ul>
+  <p>If you’d like to invite a member of our team to participate in your event, please send us the details
+    below.</p>
+
+  <p>
+    <label for="event-date">Event date</label>
+    <input type="date" id="event-date" name="event_date" required="required">
+  </p>
+  <p>
+    <label for="location">Location</label>
+    <input required="required" type="text" id="location" name="location" value="" size="60" maxlength="128"/>
+  </p>
+  <p>
+    <label for="event-title">Event title</label>
+    <input required="required" type="text" id="event-title" name="event_title" value="" size="60" maxlength="128"/>
+  </p>
+  <p>
+    <label for="name">Name</label>
+    <input required="required" type="text" id="name" name="name" value="" size="60" maxlength="128"/>
+  </p>
+  <p>
+    <label for="organisation">Organisation</label>
+    <input required="required" type="text" id="organisation" name="organisation" value="" size="60" maxlength="128"/>
+  </p>
+  <p>
+    <label for="email">Email</label>
+    <input required="required" type="email" id="email" name="email" size="60"/>
+  </p>
+  <p>
+    <label for="phone">Phone (optional)</label>
+    <input type="tel" id="phone" name="phone" pattern="[0-9]*"/>
+  </p>
+  <p>
+    <label for="website">Website (optional)</label>
+    <input type="text" id="website" name="website" value="" size="60" maxlength="128"/>
+  </p>
+  <p>
+    <label for="description-of-event">Description of event</label>
+    <textarea required="required" id="description-of-event" name="description_of_event" cols="60" rows="8"></textarea>
+  </p>
+  <p>
+    <label for="what-role-would-you-like-us-to-play">What role would you like us to play?</label>
+    <textarea required="required" id="what-role-would-you-like-us-to-play" name="what_role_would_you_like_us_to_play"
+              cols="60" rows="8"></textarea>
+  </p>
+  <p>
+    <label for="who-are-your-audience">Who is your audience?</label>
+    <textarea required="required" id="who-are-your-audience" name="who_are_your_audience" cols="60" rows="4"></textarea>
+  </p>
+  <p>
+    <label for="what-is-the-cost-for-aps-members-to-attend">What is the cost for APS members to attend?</label>
+    <input required="required" type="text" id="what-is-the-cost-for-aps-members-to-attend"
+           name="what_is_the_cost_for_aps_members_to_attend" value="" size="60" maxlength="128"/>
+  </p>
+  <p>
+    <label for="who-else-is-speaking">Who else is speaking?</label>
+    <textarea required="required" id="who-else-is-speaking" name="who_else_is_speaking" cols="60" rows="8"></textarea>
+  </p>
+  <p>
+    <label for="what-sort-of-media-coverage-do-you-expect">What sort of media coverage do you expect?</label>
+    <textarea required="required" id="what-sort-of-media-coverage-do-you-expect"
+              name="what_sort_of_media_coverage_do_you_expect" cols="60" rows="4"></textarea>
+  </p>
+  <p>
+    <label for="when-do-we-need-to-confirm-our-participation-by">When do we need to confirm our participation
+      by?</label>
+    <input type="date" name="when_do_we_need_to_confirm_our_participation_by"
+           id="when-do-we-need-to-confirm-our-participation-by" required="required">
+  </p>
+  <input type="hidden" name="form" value="events"/>
+  <input type="hidden" name="site_url" value="{{site.url}}"/>
+  <input type="submit" value="Submit"/>
+
+</form>
+


### PR DESCRIPTION
Closes #105.
We host the form in jekyll, but the form action is to [script.google.com]. After submitting, there is a very simple thankyou page: 
![image](https://cloud.githubusercontent.com/assets/2324569/21632066/5906c778-d296-11e6-8525-975fb3c2f37d.png)

For testing, if JEKYLL_ENV != production then `?test=1` is appended to the path and the email is not sent:
![image](https://cloud.githubusercontent.com/assets/2324569/21754631/5487b4e4-d658-11e6-8d99-6ffd454c1d9d.png)

