### PR TITLE
Fix previewing changes in circle artefacts

### DIFF
--- a/bin/buildrc
+++ b/bin/buildrc
@@ -22,7 +22,7 @@ case "${GITBRANCH}" in
       # Configure jekyll to be statically hosted on circleci.
       # TODO remove hardcoded parameters as much as possible - but where does 71211972 come from?
       export DTA_SITE_URL="https://${CIRCLE_BUILD_NUM}-71211972-gh.circle-artifacts.com"
-      export DTA_SITE_BASEURL="/${CIRCLE_NODE_INDEX}${HOME}${CIRCLE_PROJECT_REPONAME}/_site"
+      export DTA_SITE_BASEURL="/${CIRCLE_NODE_INDEX}${HOME}/${CIRCLE_PROJECT_REPONAME}/_site"
     fi
     ;;
 esac

--- a/bin/buildrc
+++ b/bin/buildrc
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+# enable pattern lists like +(...|...)
+shopt -s extglob
+
+# The master and develop branches are continuously deployed to production and staging.
+# You can also add additional branches here which will be deployed to a temporary staging site.
+# Separate branches with a | character. e.g. "+(branch1|branch2)"
+readonly DEPLOY_BRANCHES="+(annual-report)"
+
 # Use the branch name to set jekyll config:
 # - DTA_SITE_BASEURL - used in jekyll for site.baseurl
 # - DTA_SITE_URL - used in jekyll for site.url
@@ -14,20 +22,25 @@ case "${GITBRANCH}" in
   develop)
     export DTA_SITE_URL="https://dta.apps.staging.digital.gov.au"
     ;;
+  ${DEPLOY_BRANCHES})
+    export DTA_SITE_URL="https://dta-website-${GITBRANCH}.apps.staging.digital.gov.au"
+    ;;
   *)
-    if [ -z "$CIRCLECI" ]; then
-      # Assume the site is being built cloud foundry
-      export DTA_SITE_URL="https://dta-website-${GITBRANCH}.apps.staging.digital.gov.au"
-    else
+    if [[ -n ${CIRCLECI+x} ]]
+    then
       # Configure jekyll to be statically hosted on circleci.
       # TODO remove hardcoded parameters as much as possible - but where does 71211972 come from?
       export DTA_SITE_URL="https://${CIRCLE_BUILD_NUM}-71211972-gh.circle-artifacts.com"
       export DTA_SITE_BASEURL="/${CIRCLE_NODE_INDEX}${HOME}/${CIRCLE_PROJECT_REPONAME}/_site"
+    else
+      # Assume the site is being built for cloud foundry
+      export DTA_SITE_URL="https://dta-website-${GITBRANCH}.apps.staging.digital.gov.au"
     fi
     ;;
 esac
 
 # use /tmp if TMPDIR is not defined
-if [ -z "$TMPDIR" ]; then
+if [[ -z "$TMPDIR" ]]
+then
     export TMPDIR="/tmp"
 fi

--- a/bin/buildrc
+++ b/bin/buildrc
@@ -22,7 +22,7 @@ case "${GITBRANCH}" in
       # Configure jekyll to be statically hosted on circleci.
       # TODO remove hardcoded parameters as much as possible - but where does 71211972 come from?
       export DTA_SITE_URL="https://${CIRCLE_BUILD_NUM}-71211972-gh.circle-artifacts.com"
-      export DTA_SITE_BASEURL="/${CIRCLE_NODE_INDEX}${HOME}/${CIRCLE_PR_REPONAME}/_site"
+      export DTA_SITE_BASEURL="/${CIRCLE_NODE_INDEX}${HOME}${CIRCLE_PROJECT_REPONAME}/_site"
     fi
     ;;
 esac

--- a/bin/buildrc
+++ b/bin/buildrc
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Use the branch name to set jekyll config:
+# - DTA_SITE_URL - used in jekyll for site.url
+# - DTA_SITE_BASEURL - used in jekyll for site.baseurl
+export DTA_SITE_BASEURL=""
+case "$(git symbolic-ref --short -q HEAD)" in
+master)
+  export DTA_SITE_URL="https://www.dta.gov.au"
+  ;;
+develop)
+  export DTA_SITE_URL="https://dta.apps.staging.digital.gov.au"
+  ;;
+*)
+  if [ -e CIRCLECI ]; then
+    # The site will be configured to be statically hosted on circleci.
+    # TODO remove hardcoded parameters as much as possible - but where does 71211972 come from?
+    export DTA_SITE_URL="https://${CIRCLE_BUILD_NUM}-71211972-gh.circle-artifacts.com"
+    export DTA_SITE_BASEURL="/0${HOME}/${CIRCLE_PR_REPONAME}/_site"
+  else
+    # Assume the site is being built for local use
+    export DTA_SITE_URL="http://localhost:4000"
+    SITE_BASEURL_REL="$(dirname "$0")/../_site"
+    export DTA_SITE_BASEURL=`cd "${SITE_BASEURL_REL}"; pwd` # gives the absolute path
+  fi
+  ;;
+esac
+
+# use /tmp if TMPDIR is not defined
+if [ -z "$TMPDIR" ]; then
+    export TMPDIR="/tmp"
+fi

--- a/bin/buildrc
+++ b/bin/buildrc
@@ -1,29 +1,30 @@
 #!/usr/bin/env bash
 
 # Use the branch name to set jekyll config:
-# - DTA_SITE_URL - used in jekyll for site.url
 # - DTA_SITE_BASEURL - used in jekyll for site.baseurl
+# - DTA_SITE_URL - used in jekyll for site.url
+
 export DTA_SITE_BASEURL=""
-case "$(git symbolic-ref --short -q HEAD)" in
-master)
-  export DTA_SITE_URL="https://www.dta.gov.au"
-  ;;
-develop)
-  export DTA_SITE_URL="https://dta.apps.staging.digital.gov.au"
-  ;;
-*)
-  if [ -z "$CIRCLECI" ]; then
-    # Assume the site is being built for local use
-    export DTA_SITE_URL="http://localhost:4000"
-    SITE_BASEURL_REL="$(dirname "$0")/../_site"
-    export DTA_SITE_BASEURL=`cd "${SITE_BASEURL_REL}"; pwd` # gives the absolute path
-    # The site will be configured to be statically hosted on circleci.
-  else
-    # TODO remove hardcoded parameters as much as possible - but where does 71211972 come from?
-    export DTA_SITE_URL="https://${CIRCLE_BUILD_NUM}-71211972-gh.circle-artifacts.com"
-    export DTA_SITE_BASEURL="/0${HOME}/${CIRCLE_PR_REPONAME}/_site"
-  fi
-  ;;
+
+readonly GITBRANCH="$(git symbolic-ref --short -q HEAD)"
+case "${GITBRANCH}" in
+  master)
+    export DTA_SITE_URL="https://www.dta.gov.au"
+    ;;
+  develop)
+    export DTA_SITE_URL="https://dta.apps.staging.digital.gov.au"
+    ;;
+  *)
+    if [ -z "$CIRCLECI" ]; then
+      # Assume the site is being built cloud foundry
+      export DTA_SITE_URL="https://dta-website-${GITBRANCH}.apps.staging.digital.gov.au"
+    else
+      # Configure jekyll to be statically hosted on circleci.
+      # TODO remove hardcoded parameters as much as possible - but where does 71211972 come from?
+      export DTA_SITE_URL="https://${CIRCLE_BUILD_NUM}-71211972-gh.circle-artifacts.com"
+      export DTA_SITE_BASEURL="/${CIRCLE_NODE_INDEX}${HOME}/${CIRCLE_PR_REPONAME}/_site"
+    fi
+    ;;
 esac
 
 # use /tmp if TMPDIR is not defined

--- a/bin/buildrc
+++ b/bin/buildrc
@@ -12,16 +12,16 @@ develop)
   export DTA_SITE_URL="https://dta.apps.staging.digital.gov.au"
   ;;
 *)
-  if [ -e CIRCLECI ]; then
-    # The site will be configured to be statically hosted on circleci.
-    # TODO remove hardcoded parameters as much as possible - but where does 71211972 come from?
-    export DTA_SITE_URL="https://${CIRCLE_BUILD_NUM}-71211972-gh.circle-artifacts.com"
-    export DTA_SITE_BASEURL="/0${HOME}/${CIRCLE_PR_REPONAME}/_site"
-  else
+  if [ -z "$CIRCLECI" ]; then
     # Assume the site is being built for local use
     export DTA_SITE_URL="http://localhost:4000"
     SITE_BASEURL_REL="$(dirname "$0")/../_site"
     export DTA_SITE_BASEURL=`cd "${SITE_BASEURL_REL}"; pwd` # gives the absolute path
+    # The site will be configured to be statically hosted on circleci.
+  else
+    # TODO remove hardcoded parameters as much as possible - but where does 71211972 come from?
+    export DTA_SITE_URL="https://${CIRCLE_BUILD_NUM}-71211972-gh.circle-artifacts.com"
+    export DTA_SITE_BASEURL="/0${HOME}/${CIRCLE_PR_REPONAME}/_site"
   fi
   ;;
 esac

--- a/bin/checkexternal.sh
+++ b/bin/checkexternal.sh
@@ -10,6 +10,9 @@ set -e
 # cause a pipeline (for example, curl -s http://sipb.mit.edu/ | grep foo) to produce a failure return code if any command errors not just the last command of the pipeline.
 set -o pipefail
 
+# Include build env vars
+source "$(dirname "$0")/buildrc"
+
 #Use a temp _site directory
 readonly SITE="${TMPDIR}/_checkexternal_site"
 
@@ -23,5 +26,5 @@ bundle exec htmlproofer ${SITE}  \
   --file-ignore /.*feed/index\.html/ \
   --empty-alt-ignore \
   --http-status-ignore "301,302" \
-  --url-swap "https\://www.dta.gov.au:,${DTA_SITE_URL//:/\:}${DTA_SITE_BASEURL}:"
+  --url-swap "https\://www.dta.gov.au:,http\://localhost\:4000:"
 

--- a/bin/checkexternal.sh
+++ b/bin/checkexternal.sh
@@ -18,9 +18,10 @@ bundle exec jekyll build --destination ${SITE}
 
 # Run html proofer including external links
 bundle exec htmlproofer ${SITE}  \
-    --allow-hash-href \
-    --url-ignore "/mailto:.*/,/www.linkedin.com/*/" \
-    --file-ignore /.*feed/index\.html/ \
-    --empty-alt-ignore \
-    --http-status-ignore "301,302" \
-    --url-swap "http\://localhost\:4000:,https\://dta.apps.staging.digital.gov.au:,https\://www.dta.gov.au:"
+  --allow-hash-href \
+  --url-ignore "/mailto:.*/,/www.linkedin.com/*/" \
+  --file-ignore /.*feed/index\.html/ \
+  --empty-alt-ignore \
+  --http-status-ignore "301,302" \
+  --url-swap "https\://www.dta.gov.au:,${DTA_SITE_URL//:/\:}${DTA_SITE_BASEURL}:"
+

--- a/bin/cibuild.sh
+++ b/bin/cibuild.sh
@@ -9,32 +9,18 @@ set -o pipefail
 # echo out each line of the shell as it executes
 set -x
 
-# Use JEKYLL_ENV to configure jekyll-assets
-export JEKYLL_ENV=production
+# Include build env vars
+source "$(dirname "$0")/buildrc"
 
 main() {
-  readonly GITBRANCH="${CIRCLE_BRANCH}"
-
-  # Use the branch name to set the url used by jekyll
-  case "${GITBRANCH}" in
-    master)
-      readonly SITE_URL="https://www.dta.gov.au"
-      ;;
-    develop)
-      readonly SITE_URL="https://dta.apps.staging.digital.gov.au"
-      ;;
-    "")
-      readonly SITE_URL="http://localhost:4000"
-      ;;
-    *)
-      readonly SITE_URL="https://dta-website-${GITBRANCH}.apps.staging.digital.gov.au"
-      ;;
-  esac
-
   mkdir -p _site
-  echo "url: \"${SITE_URL}\"">_site/_config-url.yml
+  echo "url: \"${DTA_SITE_URL}\"">${TMPDIR}/_config-url.yml
+  echo "baseurl: \"${DTA_SITE_BASEURL}\"">>${TMPDIR}/_config-url.yml
 
-  bundle exec jekyll build --config _config.yml,_site/_config-url.yml
+  # Use JEKYLL_ENV to configure jekyll-assets
+  export JEKYLL_ENV=production
+
+  bundle exec jekyll build --config _config.yml,${TMPDIR}/_config-url.yml
 }
 
 main $@

--- a/bin/ciserve.sh
+++ b/bin/ciserve.sh
@@ -9,10 +9,9 @@ set -o pipefail
 # echo out each line of the shell as it executes
 set -x
 
-# use /tmp if TMPDIR is not defined
-if [ -z "$TMPDIR" ]; then
-    TMPDIR="/tmp"
-fi
+# Include build env vars
+source "$(dirname "$0")/buildrc"
 
 # Start a local copy of the site to test against
 bundle exec jekyll serve --no-watch --destination $TMPDIR/_pa11y_site
+

--- a/bin/citest.sh
+++ b/bin/citest.sh
@@ -13,9 +13,14 @@ set -o pipefail
 # echo out each line of the shell as it executes
 set -x
 
+# Include build env vars
+source "$(dirname "$0")/buildrc"
+
 # Run jekyll hyde
 # Note - this will clobber sitemap.xml using the site.url, so config must have the correct url.
-bundle exec jekyll hyde  --config _config.yml,_site/_config-url.yml
+bundle exec jekyll hyde  --config _config.yml,${TMPDIR}/_config-url.yml
+
+DTA_SITE_URL_ESCAPED=${DTA_SITE_URL//:/\\:}
 
 # Run a html proofer over the site
 bundle exec htmlproofer _site  \
@@ -23,7 +28,8 @@ bundle exec htmlproofer _site  \
     --allow-hash-href \
     --url-ignore "/(mailto:.*)/" \
     --file-ignore /.*feed/index\.html/ \
-    --empty-alt-ignore
+    --empty-alt-ignore \
+    --url-swap "https\://www.dta.gov.au:,${DTA_SITE_URL_ESCAPED}${DTA_SITE_BASEURL}:,${DTA_SITE_BASEURL}:"
 
 # CI should have already started a webserver in the background for pa11y to test against, but it might not be ready yet
 echo "Waiting for webserver to start..."


### PR DESCRIPTION
After circleci builds each branch, it publishes the artefacts in a static web server. With these tweaks, assets will work when viewing these artefacts. This means that links to the pages on circle can be shared to help people preview the content within the context of the site. 

e.g. https://1166-71211972-gh.circle-artifacts.com/0/home/ubuntu/dta-website/_site/index.html

![image](https://cloud.githubusercontent.com/assets/2324569/22084295/a74830dc-de23-11e6-9c85-664ec22ad987.png)

Unfortunately, clicking on links to other parts of the site do not work, as [the circle web server does not automatically append /index.html](https://discuss.circleci.com/t/circle-artifacts-com-not-using-index-html/320) like the site expects (as it does when served by nginx) However being able to share a link to the built content on circle may still be useful.

Closes #268 