### PR TITLE
Add horizontal scroll to all non-responsive tables in the annual report

### DIFF
--- a/_assets/scss/partials/_annual-report.scss
+++ b/_assets/scss/partials/_annual-report.scss
@@ -80,26 +80,15 @@
       font-weight: normal;
     }
 
+    /**
+    For financial ables, align the text to the right
+     */
     .financial {
       th,
       td {
-        max-width: 8em;
         text-align: right;
         &:first-child {
           text-align: initial;
-        }
-      }
-
-      @include media($tablet) {
-        width: initial;
-        min-width: 38em;
-
-        th:first-child,
-        td:first-child {
-          max-width: 20em;
-        }
-        td:first-child[colspan] {
-          max-width: initial;
         }
       }
     }

--- a/_assets/scss/partials/_annual-report.scss
+++ b/_assets/scss/partials/_annual-report.scss
@@ -70,7 +70,7 @@
       vertical-align: top;
     }
 
-    // The default agent sheet styles `<th>` as bold, however for an accessibile table, `<th>` can appear throughout
+    //The default agent sheet styles `<th>` as bold, however for an accessibile table, `<th>` can appear throughout
     //`<tbody>`. For the annual report we override this, and instead use `<strong>` where necessary.
     //Possibly this should be overridden globally in ui-kit.
     thead th {
@@ -83,7 +83,7 @@
     /**
     For financial tables, align the text to the right
      */
-    .financial {
+    &.financial {
       th,
       td {
         text-align: right;

--- a/_assets/scss/partials/_annual-report.scss
+++ b/_assets/scss/partials/_annual-report.scss
@@ -81,7 +81,7 @@
     }
 
     /**
-    For financial ables, align the text to the right
+    For financial tables, align the text to the right
      */
     .financial {
       th,

--- a/_assets/scss/partials/_tables.scss
+++ b/_assets/scss/partials/_tables.scss
@@ -6,12 +6,12 @@ For tables which suit a CSS responsive table approach. Collapses the table below
     //Force table to not be like a table anymore
     table, thead, tbody, th, td, tr {
       display: block;
-      width:100%;
+      width: 100%;
       -webkit-box-sizing: border-box;
       -moz-box-sizing: border-box;
       box-sizing: border-box;
-      float:left;
-      clear:left;
+      float: left;
+      clear: left;
     }
 
     //Hide table headers (but not display: none;, for accessibility)
@@ -56,8 +56,8 @@ the page width. The user can then scroll left and right with their finger to vie
 The table must be wrapped in a div with this class.
  */
 div.horizontal-scroll-table-container {
-  width:100%;
-  overflow:auto;
+  width: 100%;
+  overflow: auto;
 
   table {
     td {

--- a/_assets/scss/partials/_tables.scss
+++ b/_assets/scss/partials/_tables.scss
@@ -1,3 +1,6 @@
+/**
+For tables which suit a CSS responsive table approach. Collapses the table below the tablet breakpoint.
+ */
 .responsive-table {
   @include media($mobile-only) {
     //Force table to not be like a table anymore
@@ -42,6 +45,36 @@
       white-space: nowrap;
       content: attr(data-label);
       font-weight: bold;
+    }
+  }
+}
+
+/**
+For tables where the tabular structure must be kept intact even on mobile screens.
+Once the page width becomes smaller than the table, the container will mask the table to keep it within
+the page width. The user can then scroll left and right with their finger to view the table contents.
+The table must be wrapped in a div with this class.
+ */
+div.horizontal-scroll-table-container {
+  width:100%;
+  overflow:auto;
+
+  table {
+    td {
+      min-width: 8em;
+    }
+
+    @include media($tablet) {
+      td {
+        min-width: 10em;
+      }
+      th:first-child,
+      td:first-child {
+        max-width: 20em;
+      }
+      td:first-child[colspan] {
+        max-width: initial;
+      }
     }
   }
 }

--- a/_includes/annual-report/3.1-appropriations-tables.html
+++ b/_includes/annual-report/3.1-appropriations-tables.html
@@ -1,106 +1,113 @@
-<table class="content-table financial" >
-  <caption>Note 3.1A: Annual appropriations for 2016 (‘recoverable GST exclusive’)</caption>
-  <colgroup>
-  <col />
-  <col />
-  <col />
-  <col />
-  <col />
-  <col />
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th></th>
-      <th colspan="2"><strong>Appropriation Act</strong></th>
-      <th colspan="2"><strong>PGPA Act</strong></th>
-      <th rowspan="2"><strong>Total <br />
-        appropriation</strong></th>
-      <th rowspan="2"><strong>Appropriation applied in 2016 (current and prior years)<sup>1</sup></strong></th>
-      <th rowspan="2"><strong>Variance<sup>2</sup></strong></th>
-    </tr>
-    <tr>
-      <th></th>
-      <th><strong>Annual Appropriation</strong></th>
-      <th><strong>AFM</strong></th>
-      <th><strong>Section 74 receipts</strong></th>
-      <th><strong>Section 75 payments</strong></th>
-    </tr>
-    <tr>
-      <th></th>
-      <th><strong>$’000</strong></th>
-      <th><strong>$’000</strong></th>
-      <th><strong>$’000</strong></th>
-      <th><strong>$’000</strong></th>
-      <th><strong>$’000</strong></th>
-      <th><strong>$’000</strong></th>
-      <th><strong>$’000</strong></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>Departmental</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Ordinary annual services</td>
-      <td><strong>30,011</strong></td>
-      <td><strong>-</strong></td>
-      <td><strong>-</strong></td>
-      <td><strong>514</strong></td>
-      <td><strong>30,525</strong></td>
-      <td><strong>(20,715)</strong></td>
-      <td><strong>9,810</strong></td>
-    </tr>
-    <tr>
-      <td>Capital Budget<sup>3</sup></td>
-      <td><strong>1,500</strong></td>
-      <td><strong>-</strong></td>
-      <td><strong>-</strong></td>
-      <td><strong>-</strong></td>
-      <td><strong>1,500</strong></td>
-      <td><strong>(1,500)</strong></td>
-      <td><strong>-</strong></td>
-    </tr>
-    <tr>
-      <td>Other services</td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Equity injections<sup>4</sup></td>
-      <td><strong>2,226</strong></td>
-      <td><strong>-</strong></td>
-      <td><strong>-</strong></td>
-      <td><strong>-</strong></td>
-      <td><strong>2,226</strong></td>
-      <td><strong>-</strong></td>
-      <td><strong>2,226</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Total departmental</strong></td>
-      <td><strong>33,737</strong></td>
-      <td><strong>-</strong></td>
-      <td><strong>-</strong></td>
-      <td><strong>514</strong></td>
-      <td><strong>34,251</strong></td>
-      <td><strong>(22,215)</strong></td>
-      <td><strong>12,036</strong></td>
-    </tr>
-  </tbody>
-</table>
+{% unless include.no-scroll %}
+<div class="horizontal-scroll-table-container">
+{% endunless %}
+  <table class="content-table financial" >
+    <caption>Note 3.1A: Annual appropriations for 2016 (‘recoverable GST exclusive’)</caption>
+    <colgroup>
+    <col />
+    <col />
+    <col />
+    <col />
+    <col />
+    <col />
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th></th>
+        <th colspan="2"><strong>Appropriation Act</strong></th>
+        <th colspan="2"><strong>PGPA Act</strong></th>
+        <th rowspan="2"><strong>Total <br />
+          appropriation</strong></th>
+        <th rowspan="2"><strong>Appropriation applied in 2016 (current and prior years)<sup>1</sup></strong></th>
+        <th rowspan="2"><strong>Variance<sup>2</sup></strong></th>
+      </tr>
+      <tr>
+        <th></th>
+        <th><strong>Annual Appropriation</strong></th>
+        <th><strong>AFM</strong></th>
+        <th><strong>Section 74 receipts</strong></th>
+        <th><strong>Section 75 payments</strong></th>
+      </tr>
+      <tr>
+        <th></th>
+        <th><strong>$’000</strong></th>
+        <th><strong>$’000</strong></th>
+        <th><strong>$’000</strong></th>
+        <th><strong>$’000</strong></th>
+        <th><strong>$’000</strong></th>
+        <th><strong>$’000</strong></th>
+        <th><strong>$’000</strong></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Departmental</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Ordinary annual services</td>
+        <td><strong>30,011</strong></td>
+        <td><strong>-</strong></td>
+        <td><strong>-</strong></td>
+        <td><strong>514</strong></td>
+        <td><strong>30,525</strong></td>
+        <td><strong>(20,715)</strong></td>
+        <td><strong>9,810</strong></td>
+      </tr>
+      <tr>
+        <td>Capital Budget<sup>3</sup></td>
+        <td><strong>1,500</strong></td>
+        <td><strong>-</strong></td>
+        <td><strong>-</strong></td>
+        <td><strong>-</strong></td>
+        <td><strong>1,500</strong></td>
+        <td><strong>(1,500)</strong></td>
+        <td><strong>-</strong></td>
+      </tr>
+      <tr>
+        <td>Other services</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Equity injections<sup>4</sup></td>
+        <td><strong>2,226</strong></td>
+        <td><strong>-</strong></td>
+        <td><strong>-</strong></td>
+        <td><strong>-</strong></td>
+        <td><strong>2,226</strong></td>
+        <td><strong>-</strong></td>
+        <td><strong>2,226</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Total departmental</strong></td>
+        <td><strong>33,737</strong></td>
+        <td><strong>-</strong></td>
+        <td><strong>-</strong></td>
+        <td><strong>514</strong></td>
+        <td><strong>34,251</strong></td>
+        <td><strong>(22,215)</strong></td>
+        <td><strong>12,036</strong></td>
+      </tr>
+    </tbody>
+  </table>
+{% unless include.no-scroll %}
+</div>
+{% endunless %}
+
 <div class="notes indented">
   <div markdown="1">
 
@@ -111,80 +118,92 @@
 
 </div>
 </div>
+{% unless include.no-scroll %}
+<div class="horizontal-scroll-table-container">
+{% endunless %}
+  <table class="content-table financial">
+    <caption>Note 3.1B: Unspent annual appropriations (‘recoverable GST exclusive’)</caption>
+    <colgroup>
+      <col />
+      <col />
+    </colgroup>
+    <thead>
+    <tr>
+      <th rowspan="2" />
+      <th><strong>2016<br>$’000</strong></th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td><strong>Authority</strong></td>
+      <td />
+    </tr>
+    <tr>
+      <td><strong>Departmental<sup>1</sup></strong></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td><em>Appropriation Act (No.1) 2015–16</em></td>
+      <td><strong>7,896</strong></td>
+    </tr>
+    <tr>
+      <td><em>Appropriation Act (No.1) 2015–16</em> - cash held by the department</td>
+      <td><strong>145</strong></td>
+    </tr>
+    <tr>
+      <td><em>Appropriation Act (No.3) 2015–16</em></td>
+      <td><strong>1,370</strong></td>
+    </tr>
+    <tr>
+      <td><em>Appropriation Act (No 2) 2015–16 </em>- Non Operating Equity Injection</td>
+      <td><strong>2,226</strong></td>
+    </tr>
+    <tr>
+      <td><em><strong>Total departmental</strong></em></td>
+      <td><strong>11,637</strong></td>
+    </tr>
+    </tbody>
+  </table>
+{% unless include.no-scroll %}
+</div>
+{% endunless %}
 
-<table class="content-table financial">
-  <caption>Note 3.1B: Unspent annual appropriations (‘recoverable GST exclusive’)</caption>
-  <colgroup>
-    <col />
-    <col />
-  </colgroup>
-  <thead>
-  <tr>
-    <th rowspan="2" />
-    <th><strong>2016<br>$’000</strong></th>
-  </tr>
-  </thead>
-  <tbody>
-  <tr>
-    <td><strong>Authority</strong></td>
-    <td />
-  </tr>
-  <tr>
-    <td><strong>Departmental<sup>1</sup></strong></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td><em>Appropriation Act (No.1) 2015–16</em></td>
-    <td><strong>7,896</strong></td>
-  </tr>
-  <tr>
-    <td><em>Appropriation Act (No.1) 2015–16</em> - cash held by the department</td>
-    <td><strong>145</strong></td>
-  </tr>
-  <tr>
-    <td><em>Appropriation Act (No.3) 2015–16</em></td>
-    <td><strong>1,370</strong></td>
-  </tr>
-  <tr>
-    <td><em>Appropriation Act (No 2) 2015–16 </em>- Non Operating Equity Injection</td>
-    <td><strong>2,226</strong></td>
-  </tr>
-  <tr>
-    <td><em><strong>Total departmental</strong></em></td>
-    <td><strong>11,637</strong></td>
-  </tr>
-  </tbody>
-</table>
 <div class="notes indented" markdown="1">
 
 1. The current year Equity injection is shown exclusive of the Section 51 Permanent Quarantine, which has reduced contributed equity by $2.226 million.
 
 </div>
+{% unless include.no-scroll %}
+<div class="horizontal-scroll-table-container">
+{% endunless %}
+  <table class="content-table financial">
+    <caption>Note 3.1C: Disclosure by agent in relation to annual and special appropriations (‘recoverable GST exclusive’)</caption>
+    <colgroup>
+      <col />
+      <col />
+    </colgroup>
+    <thead>
+    <tr>
+      <th></th>
+      <th><strong>Shared Service Centre<br>2016<br>$’000</strong>
+      </th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>Total receipts</td>
+      <td><strong>-</strong></td>
+    </tr>
+    <tr>
+      <td>Total payments</td>
+      <td><strong>22,215</strong></td>
+    </tr>
+    </tbody>
+  </table>
+{% unless include.no-scroll %}
+</div>
+{% endunless %}
 
-<table class="content-table financial">
-  <caption>Note 3.1C: Disclosure by agent in relation to annual and special appropriations (‘recoverable GST exclusive’)</caption>
-  <colgroup>
-    <col />
-    <col />
-  </colgroup>
-  <thead>
-  <tr>
-    <th></th>
-    <th><strong>Shared Service Centre<br>2016<br>$’000</strong>
-    </th>
-  </tr>
-  </thead>
-  <tbody>
-  <tr>
-    <td>Total receipts</td>
-    <td><strong>-</strong></td>
-  </tr>
-  <tr>
-    <td>Total payments</td>
-    <td><strong>22,215</strong></td>
-  </tr>
-  </tbody>
-</table>
 <div class="notes indented" markdown="1">
 
 During 2015–16, the Shared Services Centre provided the DTO with Treasury services.

--- a/pages/who-we-are/corporate/annual-report-15-16/02-program-performance.md
+++ b/pages/who-we-are/corporate/annual-report-15-16/02-program-performance.md
@@ -187,138 +187,139 @@ The DTO recorded an operating surplus of $1.92 million for 2015–16. At 30 June
 The DTO’s financial statements are presented in Part 4 of this annual report. The Australian National Audit Office issued an unmodified audit opinion of the statements on 16 September 2016. As 2015–16 was the first year of operation for the DTO, there are no comparative figures presented in the financial statements.
 
 Tables 2 and 3 summarise the agency’s total resources and total expenses for the year.
-
-<table class="content-table financial" summary="Table 2 Resource statement">
- <caption><strong>Table 2</strong> Resource statement</caption>
-    <colgroup>
-    <col>
-    <col>
-    <col>
-    <col>
-    <col>
-    </colgroup>
-    <thead>
-      <tr>
-        <td>&nbsp; </td>
-        <td>&nbsp; </td>
-        <th id="bc1" headers="">Actual available appropriation <br>
-          for 2015–16</th>
-        <th id="bc2" headers="">Payments <br>
-          made <br>
-          2015–16</th>
-        <th id="bc3" headers="">Remaining balance <br>
-          2015–16</th>
-      </tr>
-      <tr>
-        <td>&nbsp; </td>
-        <td>&nbsp; </td>
-        <td headers="bc1">$’000<br>
-          (a)</td>
-        <td headers="bc2">$’000<br>
-          (b)</td>
-        <td headers="bc3">$’000<br>
-          (a) – (b)</td>
-      </tr>
+<div class="horizontal-scroll-table-container">
+  <table class="content-table financial" summary="Table 2 Resource statement">
+    <caption><strong>Table 2</strong> Resource statement</caption>
+      <colgroup>
+        <col>
+        <col>
+        <col>
+        <col>
+        <col>
+      </colgroup>
+      <thead>
+        <tr>
+          <td>&nbsp; </td>
+          <td>&nbsp; </td>
+          <th id="bc1" headers="">Actual available appropriation <br>
+            for 2015–16</th>
+          <th id="bc2" headers="">Payments <br>
+            made <br>
+            2015–16</th>
+          <th id="bc3" headers="">Remaining balance <br>
+            2015–16</th>
+        </tr>
+        <tr>
+          <td>&nbsp; </td>
+          <td>&nbsp; </td>
+          <td headers="bc1">$’000<br>
+            (a)</td>
+          <td headers="bc2">$’000<br>
+            (b)</td>
+          <td headers="bc3">$’000<br>
+            (a) – (b)</td>
+        </tr>
       </thead>
-    <tbody>
-      <tr>
-        <th id="br1"><strong>Ordinary annual services</strong><sup>1</sup></th>
-        <td>&nbsp;</td>
-        <td>
-        </td><td>
-        </td><td>
-      </td></tr>
-      <tr>
-        <th id="br2" headers="br1">Departmental appropriation<sup>2</sup></th>
-        <td>&nbsp;</td>
-        <td headers="br1 br2 bc1">32,025</td>
-        <td headers="br1 br2 bc2">22,215</td>
-        <td headers="br1 br2 bc3">9,810</td>
-      </tr>
-      <tr>
-        <th id="br3" headers="br1">Total</th>
-        <td>&nbsp;</td>
-        <td headers="br1 br3 bc1">32,025</td>
-        <td headers="br1 br3 bc2">22,215</td>
-        <td headers="br1 br3 bc3">9,810</td>
-      </tr>
-      <tr>
-        <th id="br4" headers="br1">Total ordinary annual services</th>
-        <td headers="br1 br4">A</td>
-        <td headers="br1 br4 bc1">32,025</td>
-        <td headers="br1 br4 bc2">22,215</td>
-        <td>
-      </td></tr>
-      <tr>
-        <td colspan="5"></td>
-      </tr>
-      <tr>
-        <th id="br5"><strong>Departmental non-operating</strong></th>
-        <td>&nbsp;</td>
-        <td>
-        </td><td>
-        </td><td>
-      </td></tr>
-      <tr>
-        <th id="br6" headers="br5">Equity injections</th>
-        <td>&nbsp;</td>
-        <td headers="br5 br6 bc1">2,226</td>
-        <td headers="br5 br6 bc2">–</td>
-        <td headers="br5 br6 bc3">2,226</td>
-      </tr>
-      <tr>
-        <th id="br7" headers="br5">Total</th>
-        <td>&nbsp;</td>
-        <td headers="br5 br7 bc1">2,226</td>
-        <td headers="br5 br7 bc2">–</td>
-        <td headers="br5 br7 bc3">2,226</td>
-      </tr>
-      <tr>
-        <th id="br8" headers="br5">Total other services</th>
-        <td headers="br5 br8">B</td>
-        <td headers="br5 br8 bc1">2,226</td>
-        <td headers="br5 br8 bc2">–</td>
-        <td>
-      </td></tr>
-      <tr>
-        <td colspan="5"></td>
-      </tr>
-      <tr>
-        <th id="br9" headers="">Total available annual appropriations and payments</th>
-        <td>&nbsp;</td>
-        <td headers="br9 bc1">34,251</td>
-        <td headers="br9 bc2">22,215</td>
-        <td>
-      </td></tr>
-      <tr>
-        <th id="br10"><strong>Total resourcing</strong></th>
-        <td>&nbsp;</td>
-        <td>
-        </td><td>
-        </td><td>
-      </td></tr>
+      <tbody>
+        <tr>
+          <th id="br1"><strong>Ordinary annual services</strong><sup>1</sup></th>
+          <td>&nbsp;</td>
+          <td>
+          </td><td>
+          </td><td>
+        </td></tr>
+        <tr>
+          <th id="br2" headers="br1">Departmental appropriation<sup>2</sup></th>
+          <td>&nbsp;</td>
+          <td headers="br1 br2 bc1">32,025</td>
+          <td headers="br1 br2 bc2">22,215</td>
+          <td headers="br1 br2 bc3">9,810</td>
+        </tr>
+        <tr>
+          <th id="br3" headers="br1">Total</th>
+          <td>&nbsp;</td>
+          <td headers="br1 br3 bc1">32,025</td>
+          <td headers="br1 br3 bc2">22,215</td>
+          <td headers="br1 br3 bc3">9,810</td>
+        </tr>
+        <tr>
+          <th id="br4" headers="br1">Total ordinary annual services</th>
+          <td headers="br1 br4">A</td>
+          <td headers="br1 br4 bc1">32,025</td>
+          <td headers="br1 br4 bc2">22,215</td>
+          <td>
+          </td>
+        </tr>
+        <tr>
+          <td colspan="5"></td>
+        </tr>
+        <tr>
+          <th id="br5"><strong>Departmental non-operating</strong></th>
+          <td>&nbsp;</td>
+          <td>
+          </td><td>
+          </td><td>
+        </td></tr>
+        <tr>
+          <th id="br6" headers="br5">Equity injections</th>
+          <td>&nbsp;</td>
+          <td headers="br5 br6 bc1">2,226</td>
+          <td headers="br5 br6 bc2">–</td>
+          <td headers="br5 br6 bc3">2,226</td>
+        </tr>
+        <tr>
+          <th id="br7" headers="br5">Total</th>
+          <td>&nbsp;</td>
+          <td headers="br5 br7 bc1">2,226</td>
+          <td headers="br5 br7 bc2">–</td>
+          <td headers="br5 br7 bc3">2,226</td>
+        </tr>
+        <tr>
+          <th id="br8" headers="br5">Total other services</th>
+          <td headers="br5 br8">B</td>
+          <td headers="br5 br8 bc1">2,226</td>
+          <td headers="br5 br8 bc2">–</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td colspan="5"></td>
+        </tr>
+        <tr>
+          <th id="br9" headers="">Total available annual appropriations and payments</th>
+          <td>&nbsp;</td>
+          <td headers="br9 bc1">34,251</td>
+          <td headers="br9 bc2">22,215</td>
+          <td></td>
+        </tr>
+        <tr>
+          <th id="br10"><strong>Total resourcing</strong></th>
+          <td>&nbsp;</td>
+          <td></td>
+          <td></td>
+          <td></td>
+        </tr>
       <tr>
         <th id="br11" headers="br10">A+B</th>
         <td>&nbsp;</td>
         <td headers="br10 br11 bc1">34,251</td>
         <td headers="br10 br11 bc2">22,215</td>
-        <td>
-      </td></tr>
+        <td></td>
+      </tr>
       <tr>
         <th id="br12" headers="br10">Total net resourcing for DTO</th>
         <td>&nbsp;</td>
         <td headers="br10 br12 bc1">34,251</td>
         <td headers="br10 br12 bc2">22,215</td>
-        <td>
-      </td></tr>
+        <td></td>
+      </tr>
     </tbody>
   </table>
+  <ol>
+    <li>Appropriation Act (No.1) 2015–16 and Appropriation Act (No.3) 2015–16.</li>
+    <li>Includes an amount of $1.500 million in 2015–16 for the Departmental Capital Budget. For accounting purposes this amount has been designated as ‘contribution by owners’.</li>
+  </ol>
+</div>
 
-  1. Appropriation Act (No.1) 2015–16 and Appropriation Act (No.3) 2015–16.<br>
-  2. Includes an amount of $1.500 million in 2015–16 for the Departmental Capital Budget. For accounting purposes this amount has been designated as ‘contribution by owners’.
-  
-<br>
-<br>
 <table class="content-table financial" summary="Expenses for Outcome 1">
 <caption><strong>Table 3 </strong>Expenses for Outcome 1 </caption>
 <colgroup>

--- a/pages/who-we-are/corporate/annual-report-15-16/02-program-performance.md
+++ b/pages/who-we-are/corporate/annual-report-15-16/02-program-performance.md
@@ -314,12 +314,12 @@ Tables 2 and 3 summarise the agency’s total resources and total expenses for t
       </tr>
     </tbody>
   </table>
-  <ol>
-    <li>Appropriation Act (No.1) 2015–16 and Appropriation Act (No.3) 2015–16.</li>
-    <li>Includes an amount of $1.500 million in 2015–16 for the Departmental Capital Budget. For accounting purposes this amount has been designated as ‘contribution by owners’.</li>
-  </ol>
 </div>
 
+1. Appropriation Act (No.1) 2015–16 and Appropriation Act (No.3) 2015–16.
+2. Includes an amount of $1.500 million in 2015–16 for the Departmental Capital Budget. For accounting purposes this amount has been designated as ‘contribution by owners’.
+    
+<div class="horizontal-scroll-table-container">
 <table class="content-table financial" summary="Expenses for Outcome 1">
 <caption><strong>Table 3 </strong>Expenses for Outcome 1 </caption>
 <colgroup>
@@ -438,6 +438,7 @@ Average staffing level (number)
 </tr>
 </tbody>
 </table>
+</div>
 
-  1. Full-year budget, including any subsequent adjustment made to the 2015–16 Budget at Additional Estimates.
-  2. Departmental appropriation combines ordinary annual services (Appropriation Act Nos 1, 3 and 5) and retained revenue receipts under section 74 of the *Public Governance, Performance and Accountability Act 2013*.
+1. Full-year budget, including any subsequent adjustment made to the 2015–16 Budget at Additional Estimates.
+2. Departmental appropriation combines ordinary annual services (Appropriation Act Nos 1, 3 and 5) and retained revenue receipts under section 74 of the *Public Governance, Performance and Accountability Act 2013*.

--- a/pages/who-we-are/corporate/annual-report-15-16/03-org-performance.md
+++ b/pages/who-we-are/corporate/annual-report-15-16/03-org-performance.md
@@ -124,211 +124,212 @@ A suite of DTO policies, procedures, guidelines and supporting documents is bein
 ### Statistics
 
 At 30 June 2016, the DTO had 71 staff employed under the Public Service Act, as shown in Table 4.
-
-<table class="content-table" summary="Table 4 Ongoing and non-ongoing active and inactive employees at 30 June 2016">
-  <caption>
-  <strong>Table 4 </strong>Ongoing and non-ongoing active and inactive employees at 30 June 2016
-  </caption>
-  <colgroup>
-  <col />
-  <col />
-  <col />
-  <col />
-  <col />
-  <col />
-  <col />
-  <col />
-  <col />
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th></th>
-      <th colspan="5"><p>Ongoing</p></th>
-      <th colspan="4"><p>Non-ongoing</p></th>
-      <th><p>Total</p></th>
-    </tr>
-    <tr>
-      <th />
-      <th colspan="3"><p>Full time</p></th>
-      <th colspan="2"><p>Part time</p></th>
-      <th colspan="2"><p>Full time</p></th>
-      <th colspan="2"><p>Part time</p></th>
-      <th />
-    </tr>
-    <tr>
-      <th />
-      <th><p>Male</p></th>
-      <th colspan="2"><p>Female</p></th>
-      <th><p>Male</p></th>
-      <th><p>Female</p></th>
-      <th><p>Male</p></th>
-      <th><p>Female</p></th>
-      <th><p>Male</p></th>
-      <th><p>Female</p></th>
-      <th />
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>APS1</td>
-      <td>0</td>
-      <td colspan="2">0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td><strong>0</strong></td>
-    </tr>
-    <tr>
-      <td>APS2</td>
-      <td>0</td>
-      <td colspan="2">0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td><strong>0</strong></td>
-    </tr>
-    <tr>
-      <td>APS3</td>
-      <td>0</td>
-      <td colspan="2">0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td><strong>0</strong></td>
-    </tr>
-    <tr>
-      <td>APS4</td>
-      <td>1</td>
-      <td colspan="2">0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>1</td>
-      <td>1</td>
-      <td>0</td>
-      <td>0</td>
-      <td><strong>3</strong></td>
-    </tr>
-    <tr>
-      <td>APS5</td>
-      <td>0</td>
-      <td colspan="2">2</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>1</td>
-      <td>0</td>
-      <td>0</td>
-      <td><strong>3</strong></td>
-    </tr>
-    <tr>
-      <td>APS6</td>
-      <td>6</td>
-      <td colspan="2">1</td>
-      <td>1</td>
-      <td>0</td>
-      <td>0</td>
-      <td>4</td>
-      <td>0</td>
-      <td>0</td>
-      <td><strong>12</strong></td>
-    </tr>
-    <tr>
-      <td>EL1</td>
-      <td>8</td>
-      <td colspan="2">8</td>
-      <td>1</td>
-      <td>0</td>
-      <td>4</td>
-      <td>1</td>
-      <td>0</td>
-      <td>1</td>
-      <td><strong>23</strong></td>
-    </tr>
-    <tr>
-      <td>EL2</td>
-      <td>5</td>
-      <td colspan="2">2</td>
-      <td>0</td>
-      <td>2</td>
-      <td>9</td>
-      <td>4</td>
-      <td>0</td>
-      <td>1</td>
-      <td><strong>23</strong></td>
-    </tr>
-    <tr>
-      <td>SES1</td>
-      <td>0</td>
-      <td colspan="2">1</td>
-      <td>0</td>
-      <td>0</td>
-      <td>2</td>
-      <td>1</td>
-      <td>0</td>
-      <td>0</td>
-      <td><strong>4</strong></td>
-    </tr>
-    <tr>
-      <td>SES2</td>
-      <td>0</td>
-      <td colspan="2">1</td>
-      <td>0</td>
-      <td>0</td>
-      <td>1</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td><strong>2</strong></td>
-    </tr>
-    <tr>
-      <td>SES3</td>
-      <td>0</td>
-      <td colspan="2">0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td><strong>0</strong></td>
-    </tr>
-    <tr>
-      <td>CEO</td>
-      <td>1</td>
-      <td colspan="2">0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td><strong>1</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Total</strong></td>
-      <td><strong>21</strong></td>
-      <td colspan="2"><strong>15</strong></td>
-      <td><strong>2</strong></td>
-      <td><strong>2</strong></td>
-      <td><strong>17</strong></td>
-      <td><strong>12</strong></td>
-      <td><strong>0</strong></td>
-      <td><strong>2</strong></td>
-      <td><strong>71</strong></td>
-    </tr>
-  </tbody>
-</table>
+<div class="horizontal-scroll-table-container">
+  <table class="content-table" summary="Table 4 Ongoing and non-ongoing active and inactive employees at 30 June 2016">
+    <caption>
+    <strong>Table 4 </strong>Ongoing and non-ongoing active and inactive employees at 30 June 2016
+    </caption>
+    <colgroup>
+    <col />
+    <col />
+    <col />
+    <col />
+    <col />
+    <col />
+    <col />
+    <col />
+    <col />
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th></th>
+        <th colspan="5"><p>Ongoing</p></th>
+        <th colspan="4"><p>Non-ongoing</p></th>
+        <th><p>Total</p></th>
+      </tr>
+      <tr>
+        <th />
+        <th colspan="3"><p>Full time</p></th>
+        <th colspan="2"><p>Part time</p></th>
+        <th colspan="2"><p>Full time</p></th>
+        <th colspan="2"><p>Part time</p></th>
+        <th />
+      </tr>
+      <tr>
+        <th />
+        <th><p>Male</p></th>
+        <th colspan="2"><p>Female</p></th>
+        <th><p>Male</p></th>
+        <th><p>Female</p></th>
+        <th><p>Male</p></th>
+        <th><p>Female</p></th>
+        <th><p>Male</p></th>
+        <th><p>Female</p></th>
+        <th />
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>APS1</td>
+        <td>0</td>
+        <td colspan="2">0</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0</td>
+        <td><strong>0</strong></td>
+      </tr>
+      <tr>
+        <td>APS2</td>
+        <td>0</td>
+        <td colspan="2">0</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0</td>
+        <td><strong>0</strong></td>
+      </tr>
+      <tr>
+        <td>APS3</td>
+        <td>0</td>
+        <td colspan="2">0</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0</td>
+        <td><strong>0</strong></td>
+      </tr>
+      <tr>
+        <td>APS4</td>
+        <td>1</td>
+        <td colspan="2">0</td>
+        <td>0</td>
+        <td>0</td>
+        <td>1</td>
+        <td>1</td>
+        <td>0</td>
+        <td>0</td>
+        <td><strong>3</strong></td>
+      </tr>
+      <tr>
+        <td>APS5</td>
+        <td>0</td>
+        <td colspan="2">2</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0</td>
+        <td>1</td>
+        <td>0</td>
+        <td>0</td>
+        <td><strong>3</strong></td>
+      </tr>
+      <tr>
+        <td>APS6</td>
+        <td>6</td>
+        <td colspan="2">1</td>
+        <td>1</td>
+        <td>0</td>
+        <td>0</td>
+        <td>4</td>
+        <td>0</td>
+        <td>0</td>
+        <td><strong>12</strong></td>
+      </tr>
+      <tr>
+        <td>EL1</td>
+        <td>8</td>
+        <td colspan="2">8</td>
+        <td>1</td>
+        <td>0</td>
+        <td>4</td>
+        <td>1</td>
+        <td>0</td>
+        <td>1</td>
+        <td><strong>23</strong></td>
+      </tr>
+      <tr>
+        <td>EL2</td>
+        <td>5</td>
+        <td colspan="2">2</td>
+        <td>0</td>
+        <td>2</td>
+        <td>9</td>
+        <td>4</td>
+        <td>0</td>
+        <td>1</td>
+        <td><strong>23</strong></td>
+      </tr>
+      <tr>
+        <td>SES1</td>
+        <td>0</td>
+        <td colspan="2">1</td>
+        <td>0</td>
+        <td>0</td>
+        <td>2</td>
+        <td>1</td>
+        <td>0</td>
+        <td>0</td>
+        <td><strong>4</strong></td>
+      </tr>
+      <tr>
+        <td>SES2</td>
+        <td>0</td>
+        <td colspan="2">1</td>
+        <td>0</td>
+        <td>0</td>
+        <td>1</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0</td>
+        <td><strong>2</strong></td>
+      </tr>
+      <tr>
+        <td>SES3</td>
+        <td>0</td>
+        <td colspan="2">0</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0</td>
+        <td><strong>0</strong></td>
+      </tr>
+      <tr>
+        <td>CEO</td>
+        <td>1</td>
+        <td colspan="2">0</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0</td>
+        <td><strong>1</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Total</strong></td>
+        <td><strong>21</strong></td>
+        <td colspan="2"><strong>15</strong></td>
+        <td><strong>2</strong></td>
+        <td><strong>2</strong></td>
+        <td><strong>17</strong></td>
+        <td><strong>12</strong></td>
+        <td><strong>0</strong></td>
+        <td><strong>2</strong></td>
+        <td><strong>71</strong></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 <div class="notes indented">
     <dl>
         <dt>APS</dt>
@@ -355,71 +356,72 @@ The DTO has 20 employees (28 per cent) working in Sydney and 51 employees (72 pe
 All non-SES employees are engaged under the DTO Determination 2015/01. Five SES employees are engaged via individual section 24(1) agreements and one SES employee is engaged via an external recruitment agency.
 
 The DTO Determination 2015/01 is supplemented by the Australian Public Service Enterprise Award 2015 and relevant legislative instruments. The determination provides salary bands for APS and Executive Level employees across the DTO, as shown in Table 5. There is also the provision to remunerate APS staff for specific specialist skills through individual section 24(1) arrangements.
-
-<table class="content-table" summary="Table 5 Salary ranges under DTO Determination 2015/01 at 30 June 2016">
-  <caption>
-  <strong>Table 5</strong> Salary ranges under DTO Determination 2015/01 at 30 June 2016
-  </caption>
-  <colgroup>
-  <col />
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th><p>Classification</p></th>
-      <th><p>Minimum ($)</p></th>
-      <th><p>Maximum ($)</p></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>APS1</td>
-      <td>44,088</td>
-      <td>48,415</td>
-    </tr>
-    <tr>
-      <td>APS2</td>
-      <td>49,602</td>
-      <td>54,978</td>
-    </tr>
-    <tr>
-      <td>APS3</td>
-      <td>56,411</td>
-      <td>60,946</td>
-    </tr>
-    <tr>
-      <td>APS4</td>
-      <td>63,229</td>
-      <td>68,335</td>
-    </tr>
-    <tr>
-      <td>APS5</td>
-      <td>70,492</td>
-      <td>76,813</td>
-    </tr>
-    <tr>
-      <td>APS6</td>
-      <td>77,731</td>
-      <td>91,291</td>
-    </tr>
-    <tr>
-      <td>EL1</td>
-      <td>100,620</td>
-      <td>111,542</td>
-    </tr>
-    <tr>
-      <td>EL2</td>
-      <td>116,729</td>
-      <td>138,369</td>
-    </tr>
-    <tr>
-      <td>SES (all bands)<sup>1</sup></td>
-      <td>165,360</td>
-      <td>321,480</td>
-    </tr>
-  </tbody>
-</table>
+<div class="horizontal-scroll-table-container">
+  <table class="content-table" summary="Table 5 Salary ranges under DTO Determination 2015/01 at 30 June 2016">
+    <caption>
+    <strong>Table 5</strong> Salary ranges under DTO Determination 2015/01 at 30 June 2016
+    </caption>
+    <colgroup>
+    <col />
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th><p>Classification</p></th>
+        <th><p>Minimum ($)</p></th>
+        <th><p>Maximum ($)</p></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>APS1</td>
+        <td>44,088</td>
+        <td>48,415</td>
+      </tr>
+      <tr>
+        <td>APS2</td>
+        <td>49,602</td>
+        <td>54,978</td>
+      </tr>
+      <tr>
+        <td>APS3</td>
+        <td>56,411</td>
+        <td>60,946</td>
+      </tr>
+      <tr>
+        <td>APS4</td>
+        <td>63,229</td>
+        <td>68,335</td>
+      </tr>
+      <tr>
+        <td>APS5</td>
+        <td>70,492</td>
+        <td>76,813</td>
+      </tr>
+      <tr>
+        <td>APS6</td>
+        <td>77,731</td>
+        <td>91,291</td>
+      </tr>
+      <tr>
+        <td>EL1</td>
+        <td>100,620</td>
+        <td>111,542</td>
+      </tr>
+      <tr>
+        <td>EL2</td>
+        <td>116,729</td>
+        <td>138,369</td>
+      </tr>
+      <tr>
+        <td>SES (all bands)<sup>1</sup></td>
+        <td>165,360</td>
+        <td>321,480</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 <div class="notes indented">
     <dl>
@@ -514,41 +516,43 @@ During 2015–16, two new consultancy contracts were entered into by the DTO, in
 {% include hx.html lvl=2 text="Advertising and market research" %}
 
 Under section 311A of the *Commonwealth Electoral Act 1918*, the DTO is required to report annually on its use of advertising and marketing services. During 2015–16, the DTO did not make any payments for advertising campaigns. The agency did make payments for market research services, as shown in Table 6.
+<div class="horizontal-scroll-table-container">
+  <table class="content-table" summary="Table 6 Commissions paid to market research agencies in 2015–16 (including GST)">
+    <caption>
+    <strong>Table 6</strong> Commissions paid to market research agencies in 2015–16 (including GST)
+    </caption>
+    <colgroup>
+    <col />
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th><p>Vendor</p></th>
+        <th><p>Details</p></th>
+        <th><p>Cost ($)</p></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Thinkplace </td>
+        <td>Market research on the future of identity</td>
+        <td>81,982.18</td>
+      </tr>
+      <tr>
+        <td>Deloitte Access Economics</td>
+        <td>Market research on digital identity within Australia</td>
+        <td>79,580.99</td>
+      </tr>
+      <tr>
+        <td><strong>Total</strong></td>
+        <td />
+        <td><strong>161,563.17</strong></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
-<table class="content-table" summary="Table 6 Commissions paid to market research agencies in 2015–16 (including GST)">
-  <caption>
-  <strong>Table 6</strong> Commissions paid to market research agencies in 2015–16 (including GST)
-  </caption>
-  <colgroup>
-  <col />
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th><p>Vendor</p></th>
-      <th><p>Details</p></th>
-      <th><p>Cost ($)</p></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Thinkplace </td>
-      <td>Market research on the future of identity</td>
-      <td>81,982.18</td>
-    </tr>
-    <tr>
-      <td>Deloitte Access Economics</td>
-      <td>Market research on digital identity within Australia</td>
-      <td>79,580.99</td>
-    </tr>
-    <tr>
-      <td><strong>Total</strong></td>
-      <td />
-      <td><strong>161,563.17</strong></td>
-    </tr>
-  </tbody>
-</table>
 {% include hx.html lvl=2 text="Environmental performance" %}
 
 The following summary of the DTO’s environmental management activities and performance is provided in accordance with section 516A of the *Environment Protection and Biodiversity Conservation Act 1999* (EPBC Act), which requires Australian Government entities to report on:

--- a/pages/who-we-are/corporate/annual-report-15-16/04-financial-statement.md
+++ b/pages/who-we-are/corporate/annual-report-15-16/04-financial-statement.md
@@ -220,193 +220,195 @@ The above statement should be read in conjunction with the accompanying notes.
 {% include hx.html lvl=2 text="Statement of financial position" %}
 for the period ended 30 June 2016
 
-<table class="content-table financial" summary="Statement of financial position">
-  <colgroup>
-  <col />
-  <col />
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th></th>
-      <th></th>
-      <th><strong>2016</strong></th>
-      <th>Original budget</th>
-    </tr>
-    <tr>
-      <th></th>
-      <th><strong>Notes</strong></th>
-      <th><strong>$’000</strong></th>
-      <th>$’000</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>ASSETS</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><strong>Financial assets</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Cash</td>
-      <td></td>
-      <td><strong>145</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Trade and other receivables</td>
-      <td><a href="#financial-assets">2.1A</a></td>
-      <td><strong>10,451</strong></td>
-      <td>286</td>
-    </tr>
-    <tr>
-      <td><em><strong>Total financial assets</strong></em></td>
-      <td></td>
-      <td><strong>10,596</strong></td>
-      <td>286</td>
-    </tr>
-    <tr>
-      <td><strong>Non-financial assets</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Plant and equipment</td>
-      <td><a href="#non-financial-assets">2.2A</a></td>
-      <td><strong>527</strong></td>
-      <td>1,948</td>
-    </tr>
-    <tr>
-      <td>Leasehold improvements</td>
-      <td><a href="#non-financial-assets">2.2A</a></td>
-      <td><strong>1,506</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Intangibles</td>
-      <td><a href="#non-financial-assets">2.2A</a></td>
-      <td><strong>364</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Prepayments</td>
-      <td><a href="#prepayments">2.2B</a></td>
-      <td><strong>348</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td><em><strong>Total non-financial assets</strong></em></td>
-      <td></td>
-      <td><strong>2,745</strong></td>
-      <td>1,948</td>
-    </tr>
-    <tr>
-      <td><strong>Total assets</strong></td>
-      <td></td>
-      <td><strong>13,341</strong></td>
-      <td>2,234</td>
-    </tr>
-    <tr>
-      <td><strong>LIABILITIES</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><strong>Payables</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Suppliers</td>
-      <td><a href="#payables">2.3A</a></td>
-      <td><strong>5,926</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Other payables</td>
-      <td><a href="#payables">2.3B</a></td>
-      <td><strong>100</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td><em><strong>Total payables</strong></em></td>
-      <td></td>
-      <td><strong>6,026</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td><strong>Provisions</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Employee provisions</td>
-      <td><a href="#employee-provisions">4.1A</a></td>
-      <td><strong>1,573</strong></td>
-      <td>880</td>
-    </tr>
-    <tr>
-      <td>Make good provisions</td>
-      <td><a href="#other-provisions">2.4A</a></td>
-      <td><strong>325</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td><em><strong>Total provisions</strong></em></td>
-      <td></td>
-      <td><strong>1,898</strong></td>
-      <td>880</td>
-    </tr>
-    <tr>
-      <td><em><strong>Total liabilities</strong></em></td>
-      <td></td>
-      <td><strong>7,924</strong></td>
-      <td>880</td>
-    </tr>
-    <tr>
-      <td><em><strong>Net assets</strong></em></td>
-      <td></td>
-      <td><strong>5,417</strong></td>
-      <td>1,354</td>
-    </tr>
-    <tr>
-      <td><strong>EQUITY</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Contributed equity</td>
-      <td></td>
-      <td><strong>3,492</strong></td>
-      <td>2,226</td>
-    </tr>
-    <tr>
-      <td>Retained surplus (Accumulated deficit)</td>
-      <td></td>
-      <td><strong>1,925</strong></td>
-      <td>(872)</td>
-    </tr>
-    <tr>
-      <td><em><strong>Total equity</strong></em></td>
-      <td></td>
-      <td><strong>5,417</strong></td>
-      <td>1,354</td>
-    </tr>
-  </tbody>
-</table>
- <div class="notes indented">
+<div class="horizontal-scroll-table-container">
+  <table class="content-table financial" summary="Statement of financial position">
+    <colgroup>
+    <col />
+    <col />
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th></th>
+        <th></th>
+        <th><strong>2016</strong></th>
+        <th>Original budget</th>
+      </tr>
+      <tr>
+        <th></th>
+        <th><strong>Notes</strong></th>
+        <th><strong>$’000</strong></th>
+        <th>$’000</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>ASSETS</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>Financial assets</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Cash</td>
+        <td></td>
+        <td><strong>145</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td>Trade and other receivables</td>
+        <td><a href="#financial-assets">2.1A</a></td>
+        <td><strong>10,451</strong></td>
+        <td>286</td>
+      </tr>
+      <tr>
+        <td><em><strong>Total financial assets</strong></em></td>
+        <td></td>
+        <td><strong>10,596</strong></td>
+        <td>286</td>
+      </tr>
+      <tr>
+        <td><strong>Non-financial assets</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Plant and equipment</td>
+        <td><a href="#non-financial-assets">2.2A</a></td>
+        <td><strong>527</strong></td>
+        <td>1,948</td>
+      </tr>
+      <tr>
+        <td>Leasehold improvements</td>
+        <td><a href="#non-financial-assets">2.2A</a></td>
+        <td><strong>1,506</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td>Intangibles</td>
+        <td><a href="#non-financial-assets">2.2A</a></td>
+        <td><strong>364</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td>Prepayments</td>
+        <td><a href="#prepayments">2.2B</a></td>
+        <td><strong>348</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td><em><strong>Total non-financial assets</strong></em></td>
+        <td></td>
+        <td><strong>2,745</strong></td>
+        <td>1,948</td>
+      </tr>
+      <tr>
+        <td><strong>Total assets</strong></td>
+        <td></td>
+        <td><strong>13,341</strong></td>
+        <td>2,234</td>
+      </tr>
+      <tr>
+        <td><strong>LIABILITIES</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>Payables</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Suppliers</td>
+        <td><a href="#payables">2.3A</a></td>
+        <td><strong>5,926</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td>Other payables</td>
+        <td><a href="#payables">2.3B</a></td>
+        <td><strong>100</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td><em><strong>Total payables</strong></em></td>
+        <td></td>
+        <td><strong>6,026</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td><strong>Provisions</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Employee provisions</td>
+        <td><a href="#employee-provisions">4.1A</a></td>
+        <td><strong>1,573</strong></td>
+        <td>880</td>
+      </tr>
+      <tr>
+        <td>Make good provisions</td>
+        <td><a href="#other-provisions">2.4A</a></td>
+        <td><strong>325</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td><em><strong>Total provisions</strong></em></td>
+        <td></td>
+        <td><strong>1,898</strong></td>
+        <td>880</td>
+      </tr>
+      <tr>
+        <td><em><strong>Total liabilities</strong></em></td>
+        <td></td>
+        <td><strong>7,924</strong></td>
+        <td>880</td>
+      </tr>
+      <tr>
+        <td><em><strong>Net assets</strong></em></td>
+        <td></td>
+        <td><strong>5,417</strong></td>
+        <td>1,354</td>
+      </tr>
+      <tr>
+        <td><strong>EQUITY</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Contributed equity</td>
+        <td></td>
+        <td><strong>3,492</strong></td>
+        <td>2,226</td>
+      </tr>
+      <tr>
+        <td>Retained surplus (Accumulated deficit)</td>
+        <td></td>
+        <td><strong>1,925</strong></td>
+        <td>(872)</td>
+      </tr>
+      <tr>
+        <td><em><strong>Total equity</strong></em></td>
+        <td></td>
+        <td><strong>5,417</strong></td>
+        <td>1,354</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<div class="notes indented">
   <div markdown="1">
 **Budget Variances Commentary**
 
@@ -424,152 +426,153 @@ The above statement should be read in conjunction with the accompanying notes.
 {% include hx.html lvl=2 text="Statement of changes in equity" %}
 
 for the period ended 30 June 2016
-
-<table class="content-table financial" summary="Digital Transformation Office
-Statement of changes in equity
-
-for the period ended 30 June 2016">
-  <colgroup>
-  <col />
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th></th>
-      <th><strong>2016</strong></th>
-      <th>Original budget</th>
-    </tr>
-    <tr>
-      <th></th>
-      <th><strong>$’000</strong></th>
-      <th>$’000</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>CONTRIBUTED EQUITY</td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><strong>Opening balance</strong></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Balance carried forward from previous period</td>
-      <td><strong>-</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td><strong>Adjusted opening balance</strong></td>
-      <td><strong>-</strong></td>
-      <td><strong>-</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Transactions with owners</strong></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><strong>Distributions to owners</strong></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Returns of capital:</td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Return of Appropriation (equity injection)<sup>1</sup></td>
-      <td>(2,226)</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td><strong>Contributions by owners</strong></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Restructuring<sup>2</sup></td>
-      <td>1,992</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Appropriation (equity injection)</td>
-      <td>2,226</td>
-      <td>2,226</td>
-    </tr>
-    <tr>
-      <td>Departmental Capital Budget (DCB)</td>
-      <td>1,500</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td><em><strong>Total transactions with owners</strong></em></td>
-      <td><strong>3,492</strong></td>
-      <td>2,226</td>
-    </tr>
-    <tr>
-      <td><em><strong>Closing balance as at 30 June</strong></em></td>
-      <td><strong>3,492</strong></td>
-      <td> 2,226 </td>
-    </tr>
-    <tr>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><strong>RETAINED EARNINGS</strong></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><strong>Opening balance</strong></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Balance carried forward from previous period</td>
-      <td><strong>-</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td><strong>Adjusted opening balance</strong></td>
-      <td><strong>-</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td><strong>Comprehensive income</strong></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Restructuring</td>
-      <td><strong>-</strong></td>
-      <td>(594)</td>
-    </tr>
-    <tr>
-      <td>Surplus (Deficit) for the period</td>
-      <td>1,925</td>
-      <td>(278)</td>
-    </tr>
-    <tr>
-      <td><em><strong>Total comprehensive income</strong></em></td>
-      <td><strong>1,925</strong></td>
-      <td>(872)</td>
-    </tr>
-    <tr>
-      <td><em><strong>Closing balance as at 30 June</strong></em></td>
-      <td><strong>1,925</strong></td>
-      <td> 1,354 </td>
-    </tr>
-  </tbody>
-</table>
- <div class="notes indented">
+<div class="horizontal-scroll-table-container">
+  <table class="content-table financial" summary="Digital Transformation Office
+  Statement of changes in equity
+  
+  for the period ended 30 June 2016">
+    <colgroup>
+    <col />
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th></th>
+        <th><strong>2016</strong></th>
+        <th>Original budget</th>
+      </tr>
+      <tr>
+        <th></th>
+        <th><strong>$’000</strong></th>
+        <th>$’000</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>CONTRIBUTED EQUITY</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>Opening balance</strong></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Balance carried forward from previous period</td>
+        <td><strong>-</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td><strong>Adjusted opening balance</strong></td>
+        <td><strong>-</strong></td>
+        <td><strong>-</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Transactions with owners</strong></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>Distributions to owners</strong></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Returns of capital:</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Return of Appropriation (equity injection)<sup>1</sup></td>
+        <td>(2,226)</td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td><strong>Contributions by owners</strong></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Restructuring<sup>2</sup></td>
+        <td>1,992</td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td>Appropriation (equity injection)</td>
+        <td>2,226</td>
+        <td>2,226</td>
+      </tr>
+      <tr>
+        <td>Departmental Capital Budget (DCB)</td>
+        <td>1,500</td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td><em><strong>Total transactions with owners</strong></em></td>
+        <td><strong>3,492</strong></td>
+        <td>2,226</td>
+      </tr>
+      <tr>
+        <td><em><strong>Closing balance as at 30 June</strong></em></td>
+        <td><strong>3,492</strong></td>
+        <td> 2,226 </td>
+      </tr>
+      <tr>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>RETAINED EARNINGS</strong></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>Opening balance</strong></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Balance carried forward from previous period</td>
+        <td><strong>-</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td><strong>Adjusted opening balance</strong></td>
+        <td><strong>-</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td><strong>Comprehensive income</strong></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Restructuring</td>
+        <td><strong>-</strong></td>
+        <td>(594)</td>
+      </tr>
+      <tr>
+        <td>Surplus (Deficit) for the period</td>
+        <td>1,925</td>
+        <td>(278)</td>
+      </tr>
+      <tr>
+        <td><em><strong>Total comprehensive income</strong></em></td>
+        <td><strong>1,925</strong></td>
+        <td>(872)</td>
+      </tr>
+      <tr>
+        <td><em><strong>Closing balance as at 30 June</strong></em></td>
+        <td><strong>1,925</strong></td>
+        <td> 1,354 </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<div class="notes indented">
   <div markdown="1">
 1 Return of appropriation under section 51 of PGPA Act reflects the return of $2.226m of unused funding for the development of the Grants Warehouse appropriated to the Digital Transformation Office in *Appropriation Act 2 2015/16*.
 
@@ -582,115 +585,117 @@ The above statement should be read in conjunction with the accompanying notes.
 {% include hx.html lvl=2 text="Statement of changes in equity" %}
 for the period ended 30 June 2016
 
-<table class="content-table financial" summary="Digital Transformation Office
-Statement of changes in equity
-
-for the period ended 30 June 2016">
-  <colgroup>
-  <col />
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th></th>
-      <th><strong>2016</strong></th>
-      <th>Original budget</th>
-    </tr>
-    <tr>
-      <th></th>
-      <th><strong>$’000</strong></th>
-      <th>$’000</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>TOTAL EQUITY</strong></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><strong>Opening balance</strong></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Balance carried forward from previous period</td>
-      <td><strong>-</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td><strong>Adjusted opening balance</strong></td>
-      <td><strong>-</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td><strong>Comprehensive income</strong></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Surplus (Deficit) for the period</td>
-      <td><strong>1,925</strong></td>
-      <td>(278)</td>
-    </tr>
-    <tr>
-      <td><strong>Total comprehensive income</strong></td>
-      <td><strong>1,925</strong></td>
-      <td>(278)</td>
-    </tr>
-    <tr>
-      <td><strong>Transactions with owners</strong></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><strong>Distributions to owners</strong></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Returns of capital:</td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Return of Appropriation (equity injection)</td>
-      <td><strong>(2,226)</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td><strong>Contributions by owners</strong></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Restructuring</td>
-      <td><strong>1,992</strong></td>
-      <td>(594)</td>
-    </tr>
-    <tr>
-      <td>Appropriation (equity injection)</td>
-      <td><strong>2,226</strong></td>
-      <td>2,226</td>
-    </tr>
-    <tr>
-      <td>Departmental Capital Budget (DCB)</td>
-      <td><strong>1,500</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td><strong>Total transactions with owners</strong></td>
-      <td><strong>3,492</strong></td>
-      <td>1,632</td>
-    </tr>
-    <tr>
-      <td><strong>Closing balance as at 30 June</strong></td>
-      <td><strong>5,417</strong></td>
-      <td>1,354</td>
-    </tr>
-  </tbody>
-</table>
+<div class="horizontal-scroll-table-container">
+  <table class="content-table financial" summary="Digital Transformation Office
+  Statement of changes in equity
+  
+  for the period ended 30 June 2016">
+    <colgroup>
+    <col />
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th></th>
+        <th><strong>2016</strong></th>
+        <th>Original budget</th>
+      </tr>
+      <tr>
+        <th></th>
+        <th><strong>$’000</strong></th>
+        <th>$’000</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>TOTAL EQUITY</strong></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>Opening balance</strong></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Balance carried forward from previous period</td>
+        <td><strong>-</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td><strong>Adjusted opening balance</strong></td>
+        <td><strong>-</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td><strong>Comprehensive income</strong></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Surplus (Deficit) for the period</td>
+        <td><strong>1,925</strong></td>
+        <td>(278)</td>
+      </tr>
+      <tr>
+        <td><strong>Total comprehensive income</strong></td>
+        <td><strong>1,925</strong></td>
+        <td>(278)</td>
+      </tr>
+      <tr>
+        <td><strong>Transactions with owners</strong></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>Distributions to owners</strong></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Returns of capital:</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Return of Appropriation (equity injection)</td>
+        <td><strong>(2,226)</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td><strong>Contributions by owners</strong></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Restructuring</td>
+        <td><strong>1,992</strong></td>
+        <td>(594)</td>
+      </tr>
+      <tr>
+        <td>Appropriation (equity injection)</td>
+        <td><strong>2,226</strong></td>
+        <td>2,226</td>
+      </tr>
+      <tr>
+        <td>Departmental Capital Budget (DCB)</td>
+        <td><strong>1,500</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td><strong>Total transactions with owners</strong></td>
+        <td><strong>3,492</strong></td>
+        <td>1,632</td>
+      </tr>
+      <tr>
+        <td><strong>Closing balance as at 30 June</strong></td>
+        <td><strong>5,417</strong></td>
+        <td>1,354</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
   <div class="notes indented">
    <div markdown="1">
 **Accounting Policy**
@@ -716,189 +721,190 @@ The above statement should be read in conjunction with the accompanying notes.
 
 {% include hx.html lvl=2 text="Cash flow statement" %}
 for the period ended 30 June 2016
-
-<table class="content-table financial" summary="Digital Transformation Office
-Cash flow statement
-
-for the period ended 30 June 2016">
-  <colgroup>
-  <col />
-  <col />
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th></th>
-      <th></th>
-      <th><strong>2016</strong></th>
-      <th>Original budget</th>
-    </tr>
-    <tr>
-      <th></th>
-      <th><strong>Notes</strong></th>
-      <th><strong>$’000</strong></th>
-      <th>$’000</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>OPERATING ACTIVITIES</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><strong>Cash received</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Net GST received</td>
-      <td></td>
-      <td><strong>778</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Appropriations</td>
-      <td></td>
-      <td><strong>21,259</strong></td>
-      <td>28,355</td>
-    </tr>
-    <tr>
-      <td><strong>Total cash received</strong></td>
-      <td></td>
-      <td><strong>22,037</strong></td>
-      <td>28,355</td>
-    </tr>
-    <tr>
-      <td><strong>Cash used</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Employees</td>
-      <td></td>
-      <td><strong>10,575</strong></td>
-      <td>16,990</td>
-    </tr>
-    <tr>
-      <td>Suppliers</td>
-      <td></td>
-      <td><strong>9,847</strong></td>
-      <td>11,365</td>
-    </tr>
-    <tr>
-      <td><strong>Total cash used</strong></td>
-      <td></td>
-      <td><strong>20,422</strong></td>
-      <td>28,355</td>
-    </tr>
-    <tr>
-      <td><em><strong>Net cash from/(used by) operating activities</strong></em></td>
-      <td><a href="#cash-flow-reconciliation">3.2</a></td>
-      <td><strong>1,615</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td><strong>INVESTING ACTIVITIES</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><strong>Cash used</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Purchase of property, plant and equipment</td>
-      <td></td>
-      <td><strong>2,970</strong></td>
-      <td>2,226</td>
-    </tr>
-    <tr>
-      <td>Purchase of intangibles</td>
-      <td></td>
-      <td><strong>-</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td><strong>Total cash used</strong></td>
-      <td></td>
-      <td><strong>2,970</strong></td>
-      <td>2,226</td>
-    </tr>
-    <tr>
-      <td><em><strong>Net cash from/(used by) investing activities</strong></em></td>
-      <td></td>
-      <td><strong>(2,970)</strong></td>
-      <td>(2,226)</td>
-    </tr>
-    <tr>
-      <td><strong>FINANCING ACTIVITIES</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><strong>Cash received</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Contributed equity</td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Equity injections</td>
-      <td></td>
-      <td><strong>-</strong></td>
-      <td>2,226</td>
-    </tr>
-    <tr>
-      <td>Departmental capital budget</td>
-      <td></td>
-      <td><strong>1,500</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td><strong>Total cash received</strong></td>
-      <td></td>
-      <td><strong>1,500</strong></td>
-      <td>2,226</td>
-    </tr>
-    <tr>
-      <td><em><strong>Net cash from/(used by) financing activities</strong></em></td>
-      <td></td>
-      <td><strong>1,500</strong></td>
-      <td>2,226</td>
-    </tr>
-    <tr>
-      <td><em><strong>Net increase/(decrease) in cash held</strong></em></td>
-      <td></td>
-      <td><strong>145</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td colspan="2">Cash and cash equivalents at the beginning of the reporting period</td>
-      <td><strong>-</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td colspan="2"><em><strong>Cash and cash equivalents at the end of the reporting period</strong></em></td>
-      <td><strong>145</strong></td>
-      <td>-</td>
-    </tr>
-  </tbody>
-</table>
-  <div class="notes indented">
+<div class="horizontal-scroll-table-container">
+  <table class="content-table financial" summary="Digital Transformation Office
+  Cash flow statement
+  
+  for the period ended 30 June 2016">
+    <colgroup>
+    <col />
+    <col />
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th></th>
+        <th></th>
+        <th><strong>2016</strong></th>
+        <th>Original budget</th>
+      </tr>
+      <tr>
+        <th></th>
+        <th><strong>Notes</strong></th>
+        <th><strong>$’000</strong></th>
+        <th>$’000</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>OPERATING ACTIVITIES</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>Cash received</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Net GST received</td>
+        <td></td>
+        <td><strong>778</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td>Appropriations</td>
+        <td></td>
+        <td><strong>21,259</strong></td>
+        <td>28,355</td>
+      </tr>
+      <tr>
+        <td><strong>Total cash received</strong></td>
+        <td></td>
+        <td><strong>22,037</strong></td>
+        <td>28,355</td>
+      </tr>
+      <tr>
+        <td><strong>Cash used</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Employees</td>
+        <td></td>
+        <td><strong>10,575</strong></td>
+        <td>16,990</td>
+      </tr>
+      <tr>
+        <td>Suppliers</td>
+        <td></td>
+        <td><strong>9,847</strong></td>
+        <td>11,365</td>
+      </tr>
+      <tr>
+        <td><strong>Total cash used</strong></td>
+        <td></td>
+        <td><strong>20,422</strong></td>
+        <td>28,355</td>
+      </tr>
+      <tr>
+        <td><em><strong>Net cash from/(used by) operating activities</strong></em></td>
+        <td><a href="#cash-flow-reconciliation">3.2</a></td>
+        <td><strong>1,615</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td><strong>INVESTING ACTIVITIES</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>Cash used</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Purchase of property, plant and equipment</td>
+        <td></td>
+        <td><strong>2,970</strong></td>
+        <td>2,226</td>
+      </tr>
+      <tr>
+        <td>Purchase of intangibles</td>
+        <td></td>
+        <td><strong>-</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td><strong>Total cash used</strong></td>
+        <td></td>
+        <td><strong>2,970</strong></td>
+        <td>2,226</td>
+      </tr>
+      <tr>
+        <td><em><strong>Net cash from/(used by) investing activities</strong></em></td>
+        <td></td>
+        <td><strong>(2,970)</strong></td>
+        <td>(2,226)</td>
+      </tr>
+      <tr>
+        <td><strong>FINANCING ACTIVITIES</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>Cash received</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Contributed equity</td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Equity injections</td>
+        <td></td>
+        <td><strong>-</strong></td>
+        <td>2,226</td>
+      </tr>
+      <tr>
+        <td>Departmental capital budget</td>
+        <td></td>
+        <td><strong>1,500</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td><strong>Total cash received</strong></td>
+        <td></td>
+        <td><strong>1,500</strong></td>
+        <td>2,226</td>
+      </tr>
+      <tr>
+        <td><em><strong>Net cash from/(used by) financing activities</strong></em></td>
+        <td></td>
+        <td><strong>1,500</strong></td>
+        <td>2,226</td>
+      </tr>
+      <tr>
+        <td><em><strong>Net increase/(decrease) in cash held</strong></em></td>
+        <td></td>
+        <td><strong>145</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td colspan="2">Cash and cash equivalents at the beginning of the reporting period</td>
+        <td><strong>-</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td colspan="2"><em><strong>Cash and cash equivalents at the end of the reporting period</strong></em></td>
+        <td><strong>145</strong></td>
+        <td>-</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<div class="notes indented">
    <div markdown="1">
 **Budget Variances Commentary**
 
@@ -1008,191 +1014,194 @@ and reductions) are recognised as Revenue from Government when DTO gains control
 This section analyses the financial performance of the Digital Transformation Office for the year ended 2016.
 
 {% include hx.html lvl=4 text="1.1 Expenses" %}
-
-<table class="content-table financial" summary="1.1 Expenses">
-  <colgroup>
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th></th>
-      <th><strong>2016</strong></th>
-    </tr>
-    <tr>
-      <th></th>
-      <th><strong>$’000</strong></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>Note 1.1A: Employee benefits</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Wages and salaries</td>
-      <td><strong>4,961</strong></td>
-    </tr>
-    <tr>
-      <td>Superannuation</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Defined contribution plans</td>
-      <td><strong>620</strong></td>
-    </tr>
-    <tr>
-      <td>Defined benefit plans</td>
-      <td><strong>245</strong></td>
-    </tr>
-    <tr>
-      <td>Leave and other entitlements</td>
-      <td><strong>755</strong></td>
-    </tr>
-    <tr>
-      <td>Separation and redundancies</td>
-      <td><strong>5</strong></td>
-    </tr>
-    <tr>
-      <td>Secondees</td>
-      <td><strong>4,914</strong></td>
-    </tr>
-    <tr>
-      <td>Other</td>
-      <td><strong>47</strong></td>
-    </tr>
-    <tr>
-      <td><em><strong>Total employee benefits</strong></em></td>
-      <td><strong>11,547</strong></td>
-    </tr>
-  </tbody>
-</table>
- <div class="notes indented">
+<div class="horizontal-scroll-table-container">
+  <table class="content-table financial" summary="1.1 Expenses">
+    <colgroup>
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th></th>
+        <th><strong>2016</strong></th>
+      </tr>
+      <tr>
+        <th></th>
+        <th><strong>$’000</strong></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Note 1.1A: Employee benefits</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Wages and salaries</td>
+        <td><strong>4,961</strong></td>
+      </tr>
+      <tr>
+        <td>Superannuation</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Defined contribution plans</td>
+        <td><strong>620</strong></td>
+      </tr>
+      <tr>
+        <td>Defined benefit plans</td>
+        <td><strong>245</strong></td>
+      </tr>
+      <tr>
+        <td>Leave and other entitlements</td>
+        <td><strong>755</strong></td>
+      </tr>
+      <tr>
+        <td>Separation and redundancies</td>
+        <td><strong>5</strong></td>
+      </tr>
+      <tr>
+        <td>Secondees</td>
+        <td><strong>4,914</strong></td>
+      </tr>
+      <tr>
+        <td>Other</td>
+        <td><strong>47</strong></td>
+      </tr>
+      <tr>
+        <td><em><strong>Total employee benefits</strong></em></td>
+        <td><strong>11,547</strong></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<div class="notes indented">
   <div markdown="1">
 **Accounting Policy**
 
 Accounting policies for employee related expenses is contained in the People and relationships section.
   </div>
  </div>
-<table class="content-table financial" summary="Digital Transformation Office
-Notes to and forming part of the financial statements
-
-for the period ended 30 June 2016">
-  <colgroup>
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th></th>
-      <th><strong>2016</strong></th>
-    </tr>
-    <tr>
-      <th></th>
-      <th><strong>$’000</strong></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>Note 1.1B: Suppliers</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><strong>Goods and services supplied or rendered</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Consultants, legal and contractors</td>
-      <td><strong>9,424</strong></td>
-    </tr>
-    <tr>
-      <td>Equipment, repairs and maintenance</td>
-      <td><strong>879</strong></td>
-    </tr>
-    <tr>
-      <td>General expenses</td>
-      <td><strong>685</strong></td>
-    </tr>
-    <tr>
-      <td>Information technology and communication</td>
-      <td><strong>2,163</strong></td>
-    </tr>
-    <tr>
-      <td>Travel</td>
-      <td><strong>1,029</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Total goods and services supplied or rendered</strong></td>
-      <td><strong>14,180</strong></td>
-    </tr>
-    <tr>
-      <td>Goods supplied</td>
-      <td><strong>739</strong></td>
-    </tr>
-    <tr>
-      <td>Services rendered</td>
-      <td><strong>13,441</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Total goods and services supplied or rendered</strong></td>
-      <td><strong>14,180</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Other suppliers</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Operating lease rentals in connection with</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>External parties</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Minimum lease payments</td>
-      <td><strong>1,261</strong></td>
-    </tr>
-    <tr>
-      <td>Workers compensation expenses</td>
-      <td><strong>68</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Total other supplier expenses</strong></td>
-      <td><strong>1,329</strong></td>
-    </tr>
-    <tr>
-      <td><em><strong>Total suppliers</strong></em></td>
-      <td><strong>15,509</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Leasing commitments</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><strong>Commitments for minimum lease payments in relation to non-cancellable<br />
-        operating leases are payable as follows:</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Within 1 year</td>
-      <td><strong>1,242</strong></td>
-    </tr>
-    <tr>
-      <td>Between 1 to 5 years</td>
-      <td><strong>3,003</strong></td>
-    </tr>
-    <tr>
-      <td>More than 5 years</td>
-      <td><strong>-</strong></td>
-    </tr>
-    <tr>
-      <td><em><strong>Total operating lease commitments</strong></em></td>
-      <td><strong>4,245</strong></td>
-    </tr>
-  </tbody>
-</table>
- <div class="notes indented">
+<div class="horizontal-scroll-table-container">
+  <table class="content-table financial" summary="Digital Transformation Office
+  Notes to and forming part of the financial statements
+  
+  for the period ended 30 June 2016">
+    <colgroup>
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th></th>
+        <th><strong>2016</strong></th>
+      </tr>
+      <tr>
+        <th></th>
+        <th><strong>$’000</strong></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Note 1.1B: Suppliers</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>Goods and services supplied or rendered</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Consultants, legal and contractors</td>
+        <td><strong>9,424</strong></td>
+      </tr>
+      <tr>
+        <td>Equipment, repairs and maintenance</td>
+        <td><strong>879</strong></td>
+      </tr>
+      <tr>
+        <td>General expenses</td>
+        <td><strong>685</strong></td>
+      </tr>
+      <tr>
+        <td>Information technology and communication</td>
+        <td><strong>2,163</strong></td>
+      </tr>
+      <tr>
+        <td>Travel</td>
+        <td><strong>1,029</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Total goods and services supplied or rendered</strong></td>
+        <td><strong>14,180</strong></td>
+      </tr>
+      <tr>
+        <td>Goods supplied</td>
+        <td><strong>739</strong></td>
+      </tr>
+      <tr>
+        <td>Services rendered</td>
+        <td><strong>13,441</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Total goods and services supplied or rendered</strong></td>
+        <td><strong>14,180</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Other suppliers</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Operating lease rentals in connection with</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>External parties</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Minimum lease payments</td>
+        <td><strong>1,261</strong></td>
+      </tr>
+      <tr>
+        <td>Workers compensation expenses</td>
+        <td><strong>68</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Total other supplier expenses</strong></td>
+        <td><strong>1,329</strong></td>
+      </tr>
+      <tr>
+        <td><em><strong>Total suppliers</strong></em></td>
+        <td><strong>15,509</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Leasing commitments</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>Commitments for minimum lease payments in relation to non-cancellable<br />
+          operating leases are payable as follows:</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Within 1 year</td>
+        <td><strong>1,242</strong></td>
+      </tr>
+      <tr>
+        <td>Between 1 to 5 years</td>
+        <td><strong>3,003</strong></td>
+      </tr>
+      <tr>
+        <td>More than 5 years</td>
+        <td><strong>-</strong></td>
+      </tr>
+      <tr>
+        <td><em><strong>Total operating lease commitments</strong></em></td>
+        <td><strong>4,245</strong></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<div class="notes indented">
   <div markdown="1">
 Note: Commitments are GST inclusive where relevant.
 
@@ -1213,33 +1222,35 @@ A distinction is made between finance leases and operating leases. Finance lease
  </div>
 {% include hx.html lvl=4 text="1.2 Own-Source Revenue and Gains" %}
 
-<table class="content-table financial" summary="Note 1.2A: Resources received free of charge">
-  <colgroup>
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th><strong>Note 1.2A: Resources received free of charge</strong></th>
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Audit fee</td>
-      <td><strong>60</strong></td>
-    </tr>
-    <tr>
-      <td>Assets received free of charge</td>
-      <td><strong>201</strong></td>
-    </tr>
-    <tr>
-      <td><em><strong>Total resources received free of charge</strong></em></td>
-      <td><strong>261</strong></td>
-    </tr>
-  </tbody>
-</table>
- <div class="notes indented">
+<div class="horizontal-scroll-table-container">
+  <table class="content-table financial" summary="Note 1.2A: Resources received free of charge">
+    <colgroup>
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th><strong>Note 1.2A: Resources received free of charge</strong></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Audit fee</td>
+        <td><strong>60</strong></td>
+      </tr>
+      <tr>
+        <td>Assets received free of charge</td>
+        <td><strong>201</strong></td>
+      </tr>
+      <tr>
+        <td><em><strong>Total resources received free of charge</strong></em></td>
+        <td><strong>261</strong></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<div class="notes indented">
   <div markdown="1">
 **Accounting Policy**
 
@@ -1251,265 +1262,269 @@ Resources received free of charge are recognised as revenue when, and only when,
 This section analyses the Digital Transformation Office’s assets used to generate financial performance and the operating liabilities incurred as a result. Employee related information is disclosed in the People and Relationships section.
 
 {% include hx.html lvl=4 text="2.1 Financial Assets" %}
+<div class="horizontal-scroll-table-container">
 
-<table class="content-table financial" summary="&quot;&quot;">
-  <colgroup>
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th></th>
-      <th><strong>2016</strong></th>
-    </tr>
-    <tr>
-      <th></th>
-      <th><strong>$’000</strong></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>Note 2.1A: Trade and other receivables</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><strong>Goods and services receivables</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Goods and services</td>
-      <td><strong>786</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Total goods and services receivables</strong></td>
-      <td><strong>786</strong></td>
-    </tr>
-    <tr>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><strong>Appropriations receivables</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Existing programs</td>
-      <td><strong>9,266</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Total appropriations receivable</strong></td>
-      <td><strong>9,266</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Other receivables</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Statutory receivables</td>
-      <td><strong>399</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Total other receivables</strong></td>
-      <td><strong>399</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Total trade and other receivables</strong></td>
-      <td><strong>10,451</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Trade and other receivables expected to be recovered</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>No more than 12 months</td>
-      <td><strong>10,451</strong></td>
-    </tr>
-    <tr>
-      <td>More than 12 months</td>
-      <td><strong>-</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Total trade and other receivables</strong></td>
-      <td><strong>10,451</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Trade and other receivables aged as follows</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Not overdue</td>
-      <td><strong>10,451</strong></td>
-    </tr>
-    <tr>
-      <td>Overdue by</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td> 0 to 30 days</td>
-      <td><strong>-</strong></td>
-    </tr>
-    <tr>
-      <td> 31 to 60 days</td>
-      <td><strong>-</strong></td>
-    </tr>
-    <tr>
-      <td> 61 to 90 days</td>
-      <td><strong>-</strong></td>
-    </tr>
-    <tr>
-      <td> More than 90 days</td>
-      <td><strong>-</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Total receivables (gross)</strong></td>
-      <td><strong>10,451</strong></td>
-    </tr>
-  </tbody>
-</table>
- <div class="notes indented">
+  <table class="content-table financial" summary="&quot;&quot;">
+    <colgroup>
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th></th>
+        <th><strong>2016</strong></th>
+      </tr>
+      <tr>
+        <th></th>
+        <th><strong>$’000</strong></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Note 2.1A: Trade and other receivables</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>Goods and services receivables</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Goods and services</td>
+        <td><strong>786</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Total goods and services receivables</strong></td>
+        <td><strong>786</strong></td>
+      </tr>
+      <tr>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>Appropriations receivables</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Existing programs</td>
+        <td><strong>9,266</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Total appropriations receivable</strong></td>
+        <td><strong>9,266</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Other receivables</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Statutory receivables</td>
+        <td><strong>399</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Total other receivables</strong></td>
+        <td><strong>399</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Total trade and other receivables</strong></td>
+        <td><strong>10,451</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Trade and other receivables expected to be recovered</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>No more than 12 months</td>
+        <td><strong>10,451</strong></td>
+      </tr>
+      <tr>
+        <td>More than 12 months</td>
+        <td><strong>-</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Total trade and other receivables</strong></td>
+        <td><strong>10,451</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Trade and other receivables aged as follows</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Not overdue</td>
+        <td><strong>10,451</strong></td>
+      </tr>
+      <tr>
+        <td>Overdue by</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td> 0 to 30 days</td>
+        <td><strong>-</strong></td>
+      </tr>
+      <tr>
+        <td> 31 to 60 days</td>
+        <td><strong>-</strong></td>
+      </tr>
+      <tr>
+        <td> 61 to 90 days</td>
+        <td><strong>-</strong></td>
+      </tr>
+      <tr>
+        <td> More than 90 days</td>
+        <td><strong>-</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Total receivables (gross)</strong></td>
+        <td><strong>10,451</strong></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<div class="notes indented">
   <div markdown="1">
 Receivables have been assessed for impairment and no allowance has been made as at 30 June 2016.
   </div>
- </div>
-{% include hx.html lvl=4 text="2.2 Non-Financial Assets" %}
+</div>
 
-<table class="content-table financial" summary="&quot;&quot;">
-  <colgroup>
-  <col />
-  <col />
-  <col />
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th colspan="5"><strong>Note 2.2A: Reconciliation of the opening and closing balances of property, plant and equipment and intangibles<br>
-        Reconciliation of the opening and closing balances of property, plant and equipment and intangibles for 2016</strong></th>
-    </tr>
-    <tr>
-      <th></th>
-      <th>Leasehold improvements </th>
-      <th><strong>Plant and equipment</strong></th>
-      <th><strong>Computer software internally developed</strong></th>
-      <th><strong>Total</strong></th>
-    </tr>
-    <tr>
-      <th></th>
-      <th><strong>$’000</strong></th>
-      <th><strong>$’000</strong></th>
-      <th><strong>$’000</strong></th>
-      <th><strong>$’000</strong></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>As at 1 July 2015</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Gross book value</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td><strong>-</strong></td>
-    </tr>
-    <tr>
-      <td>Accumulated depreciation/amortisation and impairment</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td><strong>-</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Total as at 1 July 2015</strong></td>
-      <td><strong>-</strong></td>
-      <td><strong>-</strong></td>
-      <td><strong>-</strong></td>
-      <td><strong>-</strong></td>
-    </tr>
-    <tr>
-      <td>Additions</td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Purchase</td>
-      <td>2,644</td>
-      <td>326</td>
-      <td>-</td>
-      <td><strong>2,970</strong></td>
-    </tr>
-    <tr>
-      <td>Acquisition of entities or operations (including restructuring)</td>
-      <td>-</td>
-      <td>391</td>
-      <td>841</td>
-      <td><strong>1,232</strong></td>
-    </tr>
-    <tr>
-      <td>Depreciation and amortisation</td>
-      <td>(181)</td>
-      <td>(190)</td>
-      <td>(477)</td>
-      <td><strong>(848)</strong></td>
-    </tr>
-    <tr>
-      <td>Write-down and impairments recognised in net cost of services</td>
-      <td>(957)</td>
-      <td>-</td>
-      <td>-</td>
-      <td><strong>(957)</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Total as at 30 June 2016</strong></td>
-      <td><strong>1,506</strong></td>
-      <td><strong>527</strong></td>
-      <td><strong>364</strong></td>
-      <td><strong>2,397</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Total as at 30 June 2016 represented by</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Gross book value</td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Fair value</td>
-      <td>1,687</td>
-      <td>717</td>
-      <td>841</td>
-      <td><strong>3,245</strong></td>
-    </tr>
-    <tr>
-      <td>Accumulated depreciation/amortisation and impairment</td>
-      <td>(181)</td>
-      <td>(190)</td>
-      <td>(477)</td>
-      <td><strong>(848)</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Total as at 30 June 2016</strong></td>
-      <td><strong>1,506</strong></td>
-      <td><strong>527</strong></td>
-      <td><strong>364</strong></td>
-      <td><strong>2,397</strong></td>
-    </tr>
-  </tbody>
-</table>
- <div class="notes indented">
+{% include hx.html lvl=4 text="2.2 Non-Financial Assets" %}
+<div class="horizontal-scroll-table-container">
+  <table class="content-table financial" summary="&quot;&quot;">
+    <colgroup>
+    <col />
+    <col />
+    <col />
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th colspan="5"><strong>Note 2.2A: Reconciliation of the opening and closing balances of property, plant and equipment and intangibles<br>
+          Reconciliation of the opening and closing balances of property, plant and equipment and intangibles for 2016</strong></th>
+      </tr>
+      <tr>
+        <th></th>
+        <th>Leasehold improvements </th>
+        <th><strong>Plant and equipment</strong></th>
+        <th><strong>Computer software internally developed</strong></th>
+        <th><strong>Total</strong></th>
+      </tr>
+      <tr>
+        <th></th>
+        <th><strong>$’000</strong></th>
+        <th><strong>$’000</strong></th>
+        <th><strong>$’000</strong></th>
+        <th><strong>$’000</strong></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>As at 1 July 2015</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Gross book value</td>
+        <td>-</td>
+        <td>-</td>
+        <td>-</td>
+        <td><strong>-</strong></td>
+      </tr>
+      <tr>
+        <td>Accumulated depreciation/amortisation and impairment</td>
+        <td>-</td>
+        <td>-</td>
+        <td>-</td>
+        <td><strong>-</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Total as at 1 July 2015</strong></td>
+        <td><strong>-</strong></td>
+        <td><strong>-</strong></td>
+        <td><strong>-</strong></td>
+        <td><strong>-</strong></td>
+      </tr>
+      <tr>
+        <td>Additions</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Purchase</td>
+        <td>2,644</td>
+        <td>326</td>
+        <td>-</td>
+        <td><strong>2,970</strong></td>
+      </tr>
+      <tr>
+        <td>Acquisition of entities or operations (including restructuring)</td>
+        <td>-</td>
+        <td>391</td>
+        <td>841</td>
+        <td><strong>1,232</strong></td>
+      </tr>
+      <tr>
+        <td>Depreciation and amortisation</td>
+        <td>(181)</td>
+        <td>(190)</td>
+        <td>(477)</td>
+        <td><strong>(848)</strong></td>
+      </tr>
+      <tr>
+        <td>Write-down and impairments recognised in net cost of services</td>
+        <td>(957)</td>
+        <td>-</td>
+        <td>-</td>
+        <td><strong>(957)</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Total as at 30 June 2016</strong></td>
+        <td><strong>1,506</strong></td>
+        <td><strong>527</strong></td>
+        <td><strong>364</strong></td>
+        <td><strong>2,397</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Total as at 30 June 2016 represented by</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Gross book value</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Fair value</td>
+        <td>1,687</td>
+        <td>717</td>
+        <td>841</td>
+        <td><strong>3,245</strong></td>
+      </tr>
+      <tr>
+        <td>Accumulated depreciation/amortisation and impairment</td>
+        <td>(181)</td>
+        <td>(190)</td>
+        <td>(477)</td>
+        <td><strong>(848)</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Total as at 30 June 2016</strong></td>
+        <td><strong>1,506</strong></td>
+        <td><strong>527</strong></td>
+        <td><strong>364</strong></td>
+        <td><strong>2,397</strong></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<div class="notes indented">
   <div markdown="1">
 **Accounting policy**
 
@@ -1528,29 +1543,30 @@ Amortisation rates apply to intangibles and are based of the useful life of 2 to
 *Revaluations*
 
 Fair values for each class of asset are determined as shown below:
-
-<table class="content-table" summary="Revaluations">
-  <colgroup>
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th><em>Asset class</em></th>
-      <th><em>Fair value measurement</em></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Leasehold improvements</td>
-      <td>Depreciated replacement cost</td>
-    </tr>
-    <tr>
-      <td>Plant and equipment</td>
-      <td>Market selling price or depreciated replacement cost</td>
-    </tr>
-  </tbody>
-</table>
+<div class="horizontal-scroll-table-container">
+  <table class="content-table" summary="Revaluations">
+    <colgroup>
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th><em>Asset class</em></th>
+        <th><em>Fair value measurement</em></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Leasehold improvements</td>
+        <td>Depreciated replacement cost</td>
+      </tr>
+      <tr>
+        <td>Plant and equipment</td>
+        <td>Market selling price or depreciated replacement cost</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 *Depreciation*
 
@@ -1560,28 +1576,30 @@ Depreciation rates (useful lives), residual values and methods are reviewed at e
 
 Depreciation rates applying to each class of depreciable asset are based on the following useful lives:
 
-<table class="content-table" summary="Depreciation rates applying to each class of depreciable asset are based on the following useful lives:">
-  <colgroup>
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th />
-      <th><strong>2016</strong></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Leasehold improvements</td>
-      <td>Lease term</td>
-    </tr>
-    <tr>
-      <td>Plant and equipment</td>
-      <td>2 to 10 years</td>
-    </tr>
-  </tbody>
-</table>
+<div class="horizontal-scroll-table-container">
+  <table class="content-table" summary="Depreciation rates applying to each class of depreciable asset are based on the following useful lives:">
+    <colgroup>
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th />
+        <th><strong>2016</strong></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Leasehold improvements</td>
+        <td>Lease term</td>
+      </tr>
+      <tr>
+        <td>Plant and equipment</td>
+        <td>2 to 10 years</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 *Impairment*
 
@@ -1598,164 +1616,170 @@ An item of property, plant and equipment is derecognised upon disposal or when n
  </div>
 {% include hx.html lvl=5 text="Prepayments" %} 
 
-<table class="content-table financial" summary="Note 2.2B: Prepayments">
-  <colgroup>
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th></th>
-      <th><strong>2016</strong></th>
-    </tr>
-    <tr>
-      <th></th>
-      <th><strong>$’000</strong></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>Note 2.2B: Prepayments</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Prepayments</td>
-      <td><strong>348</strong></td>
-    </tr>
-    <tr>
-      <td><em><strong>Total prepayments</strong></em></td>
-      <td><strong>348</strong></td>
-    </tr>
-    <tr>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><strong>Prepayments expected to be recovered</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>No more than 12 months</td>
-      <td><strong>348</strong></td>
-    </tr>
-    <tr>
-      <td>More than 12 months</td>
-      <td><strong>-</strong></td>
-    </tr>
-    <tr>
-      <td><em><strong>Total prepayments</strong></em></td>
-      <td><strong>348</strong></td>
-    </tr>
-  </tbody>
-</table>
+<div class="horizontal-scroll-table-container">
+  <table class="content-table financial" summary="Note 2.2B: Prepayments">
+    <colgroup>
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th></th>
+        <th><strong>2016</strong></th>
+      </tr>
+      <tr>
+        <th></th>
+        <th><strong>$’000</strong></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Note 2.2B: Prepayments</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Prepayments</td>
+        <td><strong>348</strong></td>
+      </tr>
+      <tr>
+        <td><em><strong>Total prepayments</strong></em></td>
+        <td><strong>348</strong></td>
+      </tr>
+      <tr>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>Prepayments expected to be recovered</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>No more than 12 months</td>
+        <td><strong>348</strong></td>
+      </tr>
+      <tr>
+        <td>More than 12 months</td>
+        <td><strong>-</strong></td>
+      </tr>
+      <tr>
+        <td><em><strong>Total prepayments</strong></em></td>
+        <td><strong>348</strong></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 {% include hx.html lvl=3 text="2.3 Payables" %}
 
-<table class="content-table financial" summary="Note 2.3A: Suppliers">
-  <colgroup>
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th></th>
-      <th><strong>2016</strong></th>
-    </tr>
-    <tr>
-      <th></th>
-      <th><strong>$’000</strong></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>Note 2.3A: Suppliers</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Trade creditors and accruals</td>
-      <td><strong>5,926</strong></td>
-    </tr>
-    <tr>
-      <td><em><strong>Total suppliers</strong></em></td>
-      <td><strong>5,926</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Suppliers expected to be settled</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>No more than 12 months</td>
-      <td><strong>5,926</strong></td>
-    </tr>
-    <tr>
-      <td>More than 12 months</td>
-      <td><strong>-</strong></td>
-    </tr>
-    <tr>
-      <td><em><strong>Total suppliers</strong></em></td>
-      <td><strong>5,926</strong></td>
-    </tr>
-  </tbody>
-</table>
- <div class="notes indented">
+<div class="horizontal-scroll-table-container">
+  <table class="content-table financial" summary="Note 2.3A: Suppliers">
+    <colgroup>
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th></th>
+        <th><strong>2016</strong></th>
+      </tr>
+      <tr>
+        <th></th>
+        <th><strong>$’000</strong></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Note 2.3A: Suppliers</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Trade creditors and accruals</td>
+        <td><strong>5,926</strong></td>
+      </tr>
+      <tr>
+        <td><em><strong>Total suppliers</strong></em></td>
+        <td><strong>5,926</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Suppliers expected to be settled</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>No more than 12 months</td>
+        <td><strong>5,926</strong></td>
+      </tr>
+      <tr>
+        <td>More than 12 months</td>
+        <td><strong>-</strong></td>
+      </tr>
+      <tr>
+        <td><em><strong>Total suppliers</strong></em></td>
+        <td><strong>5,926</strong></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<div class="notes indented">
   <div markdown="1">
 Settlement is usually made within 30 days.
   </div>
  </div>
-<table class="content-table financial" summary="Note 2.3B: Other payables">
-  <colgroup>
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th>Note 2.3B: Other payables</th>
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Salaries and wages</td>
-      <td><strong>46</strong></td>
-    </tr>
-    <tr>
-      <td>Superannuation</td>
-      <td><strong>7</strong></td>
-    </tr>
-    <tr>
-      <td>Lease liability</td>
-      <td><strong>19</strong></td>
-    </tr>
-    <tr>
-      <td>Statutory payable</td>
-      <td><strong>15</strong></td>
-    </tr>
-    <tr>
-      <td>Other payables</td>
-      <td><strong>13</strong></td>
-    </tr>
-    <tr>
-      <td><em><strong>Total other payables</strong></em></td>
-      <td><strong>100</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Other payables expected to be settled</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>No more than 12 months</td>
-      <td><strong>81</strong></td>
-    </tr>
-    <tr>
-      <td>More than 12 months</td>
-      <td><strong>19</strong></td>
-    </tr>
-    <tr>
-      <td><em><strong>Total other payables</strong></em></td>
-      <td><strong>100</strong></td>
-    </tr>
-  </tbody>
-</table>
+<div class="horizontal-scroll-table-container">
+  <table class="content-table financial" summary="Note 2.3B: Other payables">
+    <colgroup>
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th>Note 2.3B: Other payables</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Salaries and wages</td>
+        <td><strong>46</strong></td>
+      </tr>
+      <tr>
+        <td>Superannuation</td>
+        <td><strong>7</strong></td>
+      </tr>
+      <tr>
+        <td>Lease liability</td>
+        <td><strong>19</strong></td>
+      </tr>
+      <tr>
+        <td>Statutory payable</td>
+        <td><strong>15</strong></td>
+      </tr>
+      <tr>
+        <td>Other payables</td>
+        <td><strong>13</strong></td>
+      </tr>
+      <tr>
+        <td><em><strong>Total other payables</strong></em></td>
+        <td><strong>100</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Other payables expected to be settled</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>No more than 12 months</td>
+        <td><strong>81</strong></td>
+      </tr>
+      <tr>
+        <td>More than 12 months</td>
+        <td><strong>19</strong></td>
+      </tr>
+      <tr>
+        <td><em><strong>Total other payables</strong></em></td>
+        <td><strong>100</strong></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
  <div class="notes indented">
   <div markdown="1">
 **Accounting Policy**
@@ -1765,106 +1789,111 @@ Supplier and other payables are recognised at amortised cost. Liabilities are re
 Financial liabilities are recognised and derecognised upon ‘trade date’.
   </div>
  </div>
+
 {% include hx.html lvl=4 text="2.4 Other Provisions" %}
 
-<table class="content-table financial" summary="Note 2.4A: Other provisions">
-  <colgroup>
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th></th>
-      <th><strong>2016</strong></th>
-    </tr>
-    <tr>
-      <th></th>
-      <th><strong>$’000</strong></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>Note 2.4A: Other provisions</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Make good provision</td>
-      <td><strong>325</strong></td>
-    </tr>
-    <tr>
-      <td><em><strong>Total other provisions</strong></em></td>
-      <td><strong>325</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Other provisions expected to be settled</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>No more than 12 months</td>
-      <td><strong>-</strong></td>
-    </tr>
-    <tr>
-      <td>More than 12 months</td>
-      <td><strong>325</strong></td>
-    </tr>
-    <tr>
-      <td><em><strong>Total other provisions</strong></em></td>
-      <td><strong>325</strong></td>
-    </tr>
-  </tbody>
-</table>
-<table class="content-table financial" summary="Make good Provision">
-  <colgroup>
-  <col />
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th></th>
-      <th><strong>Make good Provision</strong></th>
-      <th><strong>Total</strong></th>
-    </tr>
-    <tr>
-      <th></th>
-      <th><strong>$’000</strong></th>
-      <th><strong>$’000</strong></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>As at 1 July 2015</strong></td>
-      <td><strong> -</strong></td>
-      <td><strong>-</strong></td>
-    </tr>
-    <tr>
-      <td>Additional provisions made</td>
-      <td>325</td>
-      <td><strong>325</strong></td>
-    </tr>
-    <tr>
-      <td>Amounts used</td>
-      <td> -</td>
-      <td><strong>-</strong></td>
-    </tr>
-    <tr>
-      <td>Gain on reversal of provision</td>
-      <td> -</td>
-      <td><strong>-</strong></td>
-    </tr>
-    <tr>
-      <td>Unwinding of discount or change in discount rate</td>
-      <td> -</td>
-      <td><strong>-</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Total as at 30 June 2016</strong></td>
-      <td><strong> 325 </strong></td>
-      <td><strong> 325 </strong></td>
-    </tr>
-  </tbody>
-</table>
- <div class="notes indented">
+<div class="horizontal-scroll-table-container">
+  <table class="content-table financial" summary="Note 2.4A: Other provisions">
+    <colgroup>
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th></th>
+        <th><strong>2016</strong></th>
+      </tr>
+      <tr>
+        <th></th>
+        <th><strong>$’000</strong></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Note 2.4A: Other provisions</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Make good provision</td>
+        <td><strong>325</strong></td>
+      </tr>
+      <tr>
+        <td><em><strong>Total other provisions</strong></em></td>
+        <td><strong>325</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Other provisions expected to be settled</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>No more than 12 months</td>
+        <td><strong>-</strong></td>
+      </tr>
+      <tr>
+        <td>More than 12 months</td>
+        <td><strong>325</strong></td>
+      </tr>
+      <tr>
+        <td><em><strong>Total other provisions</strong></em></td>
+        <td><strong>325</strong></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<div class="horizontal-scroll-table-container">  
+  <table class="content-table financial" summary="Make good Provision">
+    <colgroup>
+    <col />
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th></th>
+        <th><strong>Make good Provision</strong></th>
+        <th><strong>Total</strong></th>
+      </tr>
+      <tr>
+        <th></th>
+        <th><strong>$’000</strong></th>
+        <th><strong>$’000</strong></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>As at 1 July 2015</strong></td>
+        <td><strong> -</strong></td>
+        <td><strong>-</strong></td>
+      </tr>
+      <tr>
+        <td>Additional provisions made</td>
+        <td>325</td>
+        <td><strong>325</strong></td>
+      </tr>
+      <tr>
+        <td>Amounts used</td>
+        <td> -</td>
+        <td><strong>-</strong></td>
+      </tr>
+      <tr>
+        <td>Gain on reversal of provision</td>
+        <td> -</td>
+        <td><strong>-</strong></td>
+      </tr>
+      <tr>
+        <td>Unwinding of discount or change in discount rate</td>
+        <td> -</td>
+        <td><strong>-</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Total as at 30 June 2016</strong></td>
+        <td><strong> 325 </strong></td>
+        <td><strong> 325 </strong></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<div class="notes indented">
   <div markdown="1">
 The entity currently has one MOU agreement for the leasing of premises which has a provision requiring the entity to restore the premises to their original condition at the conclusion of the lease.
 
@@ -1888,158 +1917,160 @@ This section identifies the Digital Transformation Office funding structure.
 </div>
 
 {% include hx.html lvl=4 text="3.2 Cash Flow Reconciliation" %}
-
-<table class="content-table financial" summary="&quot;&quot;">
-  <colgroup>
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th>Reconciliation of cash and cash equivalents as per Statement of Financial Position to Cash Flow Statement</th>
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>Cash and cash equivalents as per</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td> Cash Flow Statement</td>
-      <td><strong>145</strong></td>
-    </tr>
-    <tr>
-      <td> Statement of Financial Position</td>
-      <td><strong>145</strong></td>
-    </tr>
-    <tr>
-      <td><em><strong>Discrepancy</strong></em></td>
-      <td><strong>-</strong></td>
-    </tr>
-    <tr>
-      <td colspan="2"><strong>Reconciliation of net cost of services to net cash from operating activities</strong></td>
-    </tr>
-    <tr>
-      <td>Net cost of services</td>
-      <td><strong>(28,600)</strong></td>
-    </tr>
-    <tr>
-      <td>Revenue from Government</td>
-      <td><strong>30,525</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Adjustments for non-cash items</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Depreciation and amortisation</td>
-      <td><strong>848</strong></td>
-    </tr>
-    <tr>
-      <td>Net write down of non-financial assets</td>
-      <td><strong>957</strong></td>
-    </tr>
-    <tr>
-      <td>Other non-cash items in operating cash</td>
-      <td><strong>760</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Movements in assets and liabilities</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><strong>Assets</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>(Increase) / decrease in net receivables</td>
-      <td><strong>(10,451)</strong></td>
-    </tr>
-    <tr>
-      <td>(Increase) / decrease in prepayments</td>
-      <td><strong>(348)</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Liabilities</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Increase / (decrease) in employee provisions</td>
-      <td><strong>1,573</strong></td>
-    </tr>
-    <tr>
-      <td>Increase / (decrease) in supplier payables</td>
-      <td><strong>5,926</strong></td>
-    </tr>
-    <tr>
-      <td>Increase / (decrease) in other payables</td>
-      <td><strong>100</strong></td>
-    </tr>
-    <tr>
-      <td>Increase / (decrease) in other provisions</td>
-      <td><strong>325</strong></td>
-    </tr>
-    <tr>
-      <td><em><strong>Net cash from/(used by) operating activities</strong></em></td>
-      <td><strong>1,615</strong></td>
-    </tr>
-  </tbody>
-</table>
+<div class="horizontal-scroll-table-container">
+  <table class="content-table financial" summary="&quot;&quot;">
+    <colgroup>
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th>Reconciliation of cash and cash equivalents as per Statement of Financial Position to Cash Flow Statement</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Cash and cash equivalents as per</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td> Cash Flow Statement</td>
+        <td><strong>145</strong></td>
+      </tr>
+      <tr>
+        <td> Statement of Financial Position</td>
+        <td><strong>145</strong></td>
+      </tr>
+      <tr>
+        <td><em><strong>Discrepancy</strong></em></td>
+        <td><strong>-</strong></td>
+      </tr>
+      <tr>
+        <td colspan="2"><strong>Reconciliation of net cost of services to net cash from operating activities</strong></td>
+      </tr>
+      <tr>
+        <td>Net cost of services</td>
+        <td><strong>(28,600)</strong></td>
+      </tr>
+      <tr>
+        <td>Revenue from Government</td>
+        <td><strong>30,525</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Adjustments for non-cash items</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Depreciation and amortisation</td>
+        <td><strong>848</strong></td>
+      </tr>
+      <tr>
+        <td>Net write down of non-financial assets</td>
+        <td><strong>957</strong></td>
+      </tr>
+      <tr>
+        <td>Other non-cash items in operating cash</td>
+        <td><strong>760</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Movements in assets and liabilities</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>Assets</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>(Increase) / decrease in net receivables</td>
+        <td><strong>(10,451)</strong></td>
+      </tr>
+      <tr>
+        <td>(Increase) / decrease in prepayments</td>
+        <td><strong>(348)</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Liabilities</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Increase / (decrease) in employee provisions</td>
+        <td><strong>1,573</strong></td>
+      </tr>
+      <tr>
+        <td>Increase / (decrease) in supplier payables</td>
+        <td><strong>5,926</strong></td>
+      </tr>
+      <tr>
+        <td>Increase / (decrease) in other payables</td>
+        <td><strong>100</strong></td>
+      </tr>
+      <tr>
+        <td>Increase / (decrease) in other provisions</td>
+        <td><strong>325</strong></td>
+      </tr>
+      <tr>
+        <td><em><strong>Net cash from/(used by) operating activities</strong></em></td>
+        <td><strong>1,615</strong></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 {% include hx.html lvl=3 text="4. People and Relationships" %}
 
 This section describes a range of employment and post employment benefits provided to our people and our relationships with other key people.
 
 {% include hx.html lvl=4 text="4.1 Employee Provisions" hide-back-to-top=1 %}
-
-<table class="content-table financial" summary="&quot;&quot;">
-  <colgroup>
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th></th>
-      <th><strong>2016</strong></th>
-    </tr>
-    <tr>
-      <th></th>
-      <th><strong>$’000</strong></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>Note 4.1A: Employee provisions</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Leave</td>
-      <td><strong>1,573</strong></td>
-    </tr>
-    <tr>
-      <td><em><strong>Total employee provisions</strong></em></td>
-      <td><strong>1,573</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Employee provisions expected to be settled</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>No more than 12 months</td>
-      <td><strong>675</strong></td>
-    </tr>
-    <tr>
-      <td>More than 12 months</td>
-      <td><strong>898</strong></td>
-    </tr>
-    <tr>
-      <td><em><strong>Total employee provisions</strong></em></td>
-      <td><strong>1,573</strong></td>
-    </tr>
-  </tbody>
-</table>
- <div class="notes indented">
+<div class="horizontal-scroll-table-container">
+  <table class="content-table financial" summary="&quot;&quot;">
+    <colgroup>
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th></th>
+        <th><strong>2016</strong></th>
+      </tr>
+      <tr>
+        <th></th>
+        <th><strong>$’000</strong></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Note 4.1A: Employee provisions</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Leave</td>
+        <td><strong>1,573</strong></td>
+      </tr>
+      <tr>
+        <td><em><strong>Total employee provisions</strong></em></td>
+        <td><strong>1,573</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Employee provisions expected to be settled</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>No more than 12 months</td>
+        <td><strong>675</strong></td>
+      </tr>
+      <tr>
+        <td>More than 12 months</td>
+        <td><strong>898</strong></td>
+      </tr>
+      <tr>
+        <td><em><strong>Total employee provisions</strong></em></td>
+        <td><strong>1,573</strong></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<div class="notes indented">
   <div markdown="1">
 **Accounting Policy**
 
@@ -2065,86 +2096,87 @@ The liability for superannuation recognised as at 30 June represents outstanding
   </div>
  </div>
 {% include hx.html lvl=4 text="4.2 Senior Management Personnel Remuneration" %}
-
-<table class="content-table financial" summary="&quot;&quot;">
-  <colgroup>
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th></th>
-      <th><strong>2016</strong></th>
-    </tr>
-    <tr>
-      <th></th>
-      <th><strong>$’000</strong></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>Short-term employee benefits</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Salary</td>
-      <td><strong>1,987</strong></td>
-    </tr>
-    <tr>
-      <td>Other</td>
-      <td><strong>144</strong></td>
-    </tr>
-    <tr>
-      <td><em><strong>Total short-term employee benefits</strong></em></td>
-      <td><strong>2,131</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Post-employment benefits:</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Superannuation</td>
-      <td><strong>316</strong></td>
-    </tr>
-    <tr>
-      <td><em><strong>Total post-employment benefits</strong></em></td>
-      <td><strong>316</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Other long-term employee benefits</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Annual leave</td>
-      <td><strong>123</strong></td>
-    </tr>
-    <tr>
-      <td>Long-service leave</td>
-      <td><strong>41</strong></td>
-    </tr>
-    <tr>
-      <td><em><strong>Total other long-term benefits</strong></em></td>
-      <td><strong>164</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Termination benefits</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Termination benefits</td>
-      <td><strong>-</strong></td>
-    </tr>
-    <tr>
-      <td><em><strong>Total termination benefits</strong></em></td>
-      <td><strong>-</strong></td>
-    </tr>
-    <tr>
-      <td><em><strong>Total senior executive remuneration expenses</strong></em></td>
-      <td><strong>2,611</strong></td>
-    </tr>
-  </tbody>
-</table>
- <div class="notes indented">
+<div class="horizontal-scroll-table-container">
+  <table class="content-table financial" summary="&quot;&quot;">
+    <colgroup>
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th></th>
+        <th><strong>2016</strong></th>
+      </tr>
+      <tr>
+        <th></th>
+        <th><strong>$’000</strong></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Short-term employee benefits</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Salary</td>
+        <td><strong>1,987</strong></td>
+      </tr>
+      <tr>
+        <td>Other</td>
+        <td><strong>144</strong></td>
+      </tr>
+      <tr>
+        <td><em><strong>Total short-term employee benefits</strong></em></td>
+        <td><strong>2,131</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Post-employment benefits:</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Superannuation</td>
+        <td><strong>316</strong></td>
+      </tr>
+      <tr>
+        <td><em><strong>Total post-employment benefits</strong></em></td>
+        <td><strong>316</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Other long-term employee benefits</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Annual leave</td>
+        <td><strong>123</strong></td>
+      </tr>
+      <tr>
+        <td>Long-service leave</td>
+        <td><strong>41</strong></td>
+      </tr>
+      <tr>
+        <td><em><strong>Total other long-term benefits</strong></em></td>
+        <td><strong>164</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Termination benefits</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Termination benefits</td>
+        <td><strong>-</strong></td>
+      </tr>
+      <tr>
+        <td><em><strong>Total termination benefits</strong></em></td>
+        <td><strong>-</strong></td>
+      </tr>
+      <tr>
+        <td><em><strong>Total senior executive remuneration expenses</strong></em></td>
+        <td><strong>2,611</strong></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<div class="notes indented">
   <div markdown="1">
 During the year, the total number of senior management personnel that were utilised and are included in the above table is 21. The additional positions reported relate to the short-term employment and secondment arrangements during 2015–16 to support the establishment and development of the DTO. As at 30 June 2016, the DTO has nine senior management positions.
   </div>
@@ -2163,73 +2195,74 @@ The DTO is not aware of any material departmental quantifiable or unquantifiable
 Contingent liabilities and contingent assets are not recognised in the Statement of Financial Position but are reported in the relevant schedules and notes. They may arise from uncertainty as to the existence of a liability or asset, or represent an asset or liability in respect of which the amount cannot be reliably measured. Contingent assets are disclosed when settlement is probable but not virtually certain and contingent liabilities are disclosed when settlement is greater than remote.
 
 {% include hx.html lvl=4 text="5.2 Financial Instruments" %}
-
-<table class="content-table financial" summary="Note 5.2A: Categories of financial instruments">
-  <colgroup>
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th></th>
-      <th><strong>2016</strong></th>
-    </tr>
-    <tr>
-      <th></th>
-      <th><strong>$’000</strong></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>Note 5.2A: Categories of financial instruments</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><strong>Financial assets</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><strong>Loans and receivables</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Cash and cash equivalents</td>
-      <td><strong>145</strong></td>
-    </tr>
-    <tr>
-      <td>Goods and services receivables</td>
-      <td><strong>786</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Total loans and receivables</strong></td>
-      <td><strong>931</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Total financial assets</strong></td>
-      <td><strong>931</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Financial liabilities</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><strong>Financial liabilities measured at amortised cost</strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Trade creditors and accruals</td>
-      <td><strong>5,926</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Total financial liabilities measured at amortised cost</strong></td>
-      <td><strong>5,926</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Total financial liabilities</strong></td>
-      <td><strong>5,926</strong></td>
-    </tr>
-  </tbody>
-</table>
+<div class="horizontal-scroll-table-container">
+  <table class="content-table financial" summary="Note 5.2A: Categories of financial instruments">
+    <colgroup>
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th></th>
+        <th><strong>2016</strong></th>
+      </tr>
+      <tr>
+        <th></th>
+        <th><strong>$’000</strong></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Note 5.2A: Categories of financial instruments</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>Financial assets</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>Loans and receivables</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Cash and cash equivalents</td>
+        <td><strong>145</strong></td>
+      </tr>
+      <tr>
+        <td>Goods and services receivables</td>
+        <td><strong>786</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Total loans and receivables</strong></td>
+        <td><strong>931</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Total financial assets</strong></td>
+        <td><strong>931</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Financial liabilities</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>Financial liabilities measured at amortised cost</strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Trade creditors and accruals</td>
+        <td><strong>5,926</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Total financial liabilities measured at amortised cost</strong></td>
+        <td><strong>5,926</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Total financial liabilities</strong></td>
+        <td><strong>5,926</strong></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 **Note 5.2B: Net gains or losses on financial assets**
 
@@ -2265,58 +2298,61 @@ Level 3: Inputs for the asset or liability that are not based on observable mark
 
 **Note 5.3A: Fair value measurements, valuation techniques and inputs used**
 
-Fair value measurements at the end of the reporting period	
-<table class="content-table financial" summary="&quot;&quot;">
-  <colgroup>
-  <col />
-  <col />
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th></th>
-      <th colspan="2"><strong>Fair value measurements at the end of the reporting period</strong></th>
-      <th></th>
-    </tr>
-    <tr>
-      <th></th>
-      <th rowspan="2"><strong>2016<br>$’000</strong></th>
-      <th rowspan="2"><strong>Category (Level 1, 2 or 3<sup>1</sup>)</strong></th>
-      <th rowspan="2"><strong>Valuation Technique(s) and Inputs Used<sup>2</sup></strong></th>
-    </tr>
-    <tr>
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>Non-financial assets</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Leasehold improvements</td>
-      <td><strong>1,506</strong></td>
-      <td>2</td>
-      <td>Depreciated replacement cost/market comparables</td>
-    </tr>
-    <tr>
-      <td>Plant and equipment</td>
-      <td><strong>527</strong></td>
-      <td>2</td>
-      <td>Depreciated replacement cost/market comparables</td>
-    </tr>
-    <tr>
-      <td><strong>Total non-financial assets</strong></td>
-      <td><strong>2,033</strong></td>
-      <td></td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
- <div class="notes indented">
+Fair value measurements at the end of the reporting period
+	
+<div class="horizontal-scroll-table-container">
+  <table class="content-table financial" summary="&quot;&quot;">
+    <colgroup>
+    <col />
+    <col />
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th></th>
+        <th colspan="2"><strong>Fair value measurements at the end of the reporting period</strong></th>
+        <th></th>
+      </tr>
+      <tr>
+        <th></th>
+        <th rowspan="2"><strong>2016<br>$’000</strong></th>
+        <th rowspan="2"><strong>Category (Level 1, 2 or 3<sup>1</sup>)</strong></th>
+        <th rowspan="2"><strong>Valuation Technique(s) and Inputs Used<sup>2</sup></strong></th>
+      </tr>
+      <tr>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Non-financial assets</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Leasehold improvements</td>
+        <td><strong>1,506</strong></td>
+        <td>2</td>
+        <td>Depreciated replacement cost/market comparables</td>
+      </tr>
+      <tr>
+        <td>Plant and equipment</td>
+        <td><strong>527</strong></td>
+        <td>2</td>
+        <td>Depreciated replacement cost/market comparables</td>
+      </tr>
+      <tr>
+        <td><strong>Total non-financial assets</strong></td>
+        <td><strong>2,033</strong></td>
+        <td></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<div class="notes indented">
   <div markdown="1">
    1 DTO’s assets are held for operational purposes and not held for the purposes of deriving a profit.
    2 No revaluation has been performed in 2015–16 as all assets were transferred or purchased in the current year representing a proxy for fair value.
@@ -2336,96 +2372,98 @@ During 2015/16, PM&C relinquished $0.989 million in plant and equipment to assis
 
 As part of the Administrative Arrangement Orders issued by the Government on 21 September 2015, the Gov 2.0 function (and associated assets and liabilities) was transferred from the Department of Finance.
 
-<table class="content-table financial" summary="Note 6.1A: Departmental restructuring">
-  <colgroup>
-  <col />
-  <col />
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th></th>
-      <th><strong>Set up of DTO from PM&amp;C</strong></th>
-      <th><strong>GOV 2.0 from Finance</strong></th>
-      <th><strong>Total</strong></th>
-    </tr>
-    <tr>
-      <th></th>
-      <th><strong>$’000</strong></th>
-      <th><strong>$’000</strong></th>
-      <th><strong>$’000</strong></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>Functions assumed</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><strong>Assets recognised</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Appropriation receivable</td>
-      <td>-</td>
-      <td>431</td>
-      <td><strong>431</strong></td>
-    </tr>
-    <tr>
-      <td>Plant and equipment</td>
-      <td>989</td>
-      <td>-</td>
-      <td><strong>989</strong></td>
-    </tr>
-    <tr>
-      <td>Intangibles- internally generated</td>
-      <td>-</td>
-      <td>841</td>
-      <td><strong>841</strong></td>
-    </tr>
-    <tr>
-      <td>Other non-financial assets (prepayments)</td>
-      <td>-</td>
-      <td>162</td>
-      <td><strong>162</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Total asset recognised</strong></td>
-      <td>989</td>
-      <td>1,434</td>
-      <td><strong>2,423</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Liabilities recognised</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Employee provisions</td>
-      <td>-</td>
-      <td>431</td>
-      <td><strong>431</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Total liabilities recognised</strong></td>
-      <td>-</td>
-      <td>431</td>
-      <td><strong>431</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Net assets recognised</strong></td>
-      <td><strong>989</strong></td>
-      <td><strong>1,003</strong></td>
-      <td><strong>1,992</strong></td>
-    </tr>
-  </tbody>
-</table>
+<div class="horizontal-scroll-table-container">
+  <table class="content-table financial" summary="Note 6.1A: Departmental restructuring">
+    <colgroup>
+    <col />
+    <col />
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th></th>
+        <th><strong>Set up of DTO from PM&amp;C</strong></th>
+        <th><strong>GOV 2.0 from Finance</strong></th>
+        <th><strong>Total</strong></th>
+      </tr>
+      <tr>
+        <th></th>
+        <th><strong>$’000</strong></th>
+        <th><strong>$’000</strong></th>
+        <th><strong>$’000</strong></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Functions assumed</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>Assets recognised</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Appropriation receivable</td>
+        <td>-</td>
+        <td>431</td>
+        <td><strong>431</strong></td>
+      </tr>
+      <tr>
+        <td>Plant and equipment</td>
+        <td>989</td>
+        <td>-</td>
+        <td><strong>989</strong></td>
+      </tr>
+      <tr>
+        <td>Intangibles- internally generated</td>
+        <td>-</td>
+        <td>841</td>
+        <td><strong>841</strong></td>
+      </tr>
+      <tr>
+        <td>Other non-financial assets (prepayments)</td>
+        <td>-</td>
+        <td>162</td>
+        <td><strong>162</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Total asset recognised</strong></td>
+        <td>989</td>
+        <td>1,434</td>
+        <td><strong>2,423</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Liabilities recognised</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Employee provisions</td>
+        <td>-</td>
+        <td>431</td>
+        <td><strong>431</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Total liabilities recognised</strong></td>
+        <td>-</td>
+        <td>431</td>
+        <td><strong>431</strong></td>
+      </tr>
+      <tr>
+        <td><strong>Net assets recognised</strong></td>
+        <td><strong>989</strong></td>
+        <td><strong>1,003</strong></td>
+        <td><strong>1,992</strong></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 {% include hx.html lvl=4 text="6.2. Reporting of Outcomes" hide-back-to-top=1 %}
 

--- a/pages/who-we-are/corporate/annual-report-15-16/04-financial-statement.md
+++ b/pages/who-we-are/corporate/annual-report-15-16/04-financial-statement.md
@@ -66,145 +66,146 @@ In our opinion, at the date of this statement, there are reasonable grounds to b
 
 {% include hx.html lvl=2 text="Statement of comprehensive income" %}
 for the period ended 30 June 2016
-
-<table class="content-table financial" summary="Digital Transformation Office Statement of comprehensive income for the period ended 30 June 2016">
-  <colgroup>
-  <col />
-  <col />
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th />
-      <th />
-      <th>2016</th>
-      <th>Original budget</th>
-    </tr>
-    <tr>
-      <th />
-      <th>Notes</th>
-      <th><strong>$’000</strong></th>
-      <th>$’000</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>NET COST OF SERVICES</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><strong>Expenses</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Employee benefits</td>
-      <td><a href="#expenses">1.1A</a></td>
-      <td><strong>11,547</strong></td>
-      <td>17,276</td>
-    </tr>
-    <tr>
-      <td>Suppliers</td>
-      <td><a href="#expenses">1.1B</a></td>
-      <td><strong>15,509</strong></td>
-      <td>11,365</td>
-    </tr>
-    <tr>
-      <td>Depreciation and amortisation</td>
-      <td><a href="#non-financial-assets">2.2A</a></td>
-      <td><strong>848</strong></td>
-      <td>278</td>
-    </tr>
-    <tr>
-      <td>Write-down and impairment of assets</td>
-      <td><a href="#non-financial-assets">2.2A</a></td>
-      <td><strong>957</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td><em><strong>Total expenses</strong></em></td>
-      <td />
-      <td><strong>28,861</strong></td>
-      <td>28,919</td>
-    </tr>
-    <tr>
-      <td><strong>Own-source income</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><strong>Own-source revenue</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Resources received free of charge</td>
-      <td><a href="#own-source-revenue-and-gains">1.2A</a></td>
-      <td><strong>261</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td><em><strong>Total own-source revenue</strong></em></td>
-      <td></td>
-      <td><strong>261</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td><em><strong>Total own-source income</strong></em></td>
-      <td></td>
-      <td><strong>261</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td><em><strong>Net cost of services </strong></em></td>
-      <td></td>
-      <td><strong>28,600</strong></td>
-      <td>28,919</td>
-    </tr>
-    <tr>
-      <td>Revenue from Government</td>
-      <td></td>
-      <td><strong>30,525</strong></td>
-      <td>28,641</td>
-    </tr>
-    <tr>
-      <td colspan="2"><em><strong>Surplus/(Deficit) attributable to the Australian Government</strong></em></td>
-      <td><strong>1,925</strong></td>
-      <td>(278)</td>
-    </tr>
-    <tr>
-      <td><strong>OTHER COMPREHENSIVE INCOME</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><strong>Items not subject to subsequent reclassification to net cost of services</strong></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Changes in asset revaluation surplus</td>
-      <td></td>
-      <td><strong>-</strong></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td><em><strong>Total comprehensive income/(loss) attributable to the Australian Government</strong></em></td>
-      <td></td>
-      <td><strong>1,925</strong></td>
-      <td>(278)</td>
-    </tr>
-  </tbody>
-</table>
- <div class="notes indented">
+<div class="horizontal-scroll-table-container">
+  <table class="content-table financial" summary="Digital Transformation Office Statement of comprehensive income for the period ended 30 June 2016">
+    <colgroup>
+    <col />
+    <col />
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th />
+        <th />
+        <th>2016</th>
+        <th>Original budget</th>
+      </tr>
+      <tr>
+        <th />
+        <th>Notes</th>
+        <th><strong>$’000</strong></th>
+        <th>$’000</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>NET COST OF SERVICES</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>Expenses</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Employee benefits</td>
+        <td><a href="#expenses">1.1A</a></td>
+        <td><strong>11,547</strong></td>
+        <td>17,276</td>
+      </tr>
+      <tr>
+        <td>Suppliers</td>
+        <td><a href="#expenses">1.1B</a></td>
+        <td><strong>15,509</strong></td>
+        <td>11,365</td>
+      </tr>
+      <tr>
+        <td>Depreciation and amortisation</td>
+        <td><a href="#non-financial-assets">2.2A</a></td>
+        <td><strong>848</strong></td>
+        <td>278</td>
+      </tr>
+      <tr>
+        <td>Write-down and impairment of assets</td>
+        <td><a href="#non-financial-assets">2.2A</a></td>
+        <td><strong>957</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td><em><strong>Total expenses</strong></em></td>
+        <td />
+        <td><strong>28,861</strong></td>
+        <td>28,919</td>
+      </tr>
+      <tr>
+        <td><strong>Own-source income</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>Own-source revenue</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Resources received free of charge</td>
+        <td><a href="#own-source-revenue-and-gains">1.2A</a></td>
+        <td><strong>261</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td><em><strong>Total own-source revenue</strong></em></td>
+        <td></td>
+        <td><strong>261</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td><em><strong>Total own-source income</strong></em></td>
+        <td></td>
+        <td><strong>261</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td><em><strong>Net cost of services </strong></em></td>
+        <td></td>
+        <td><strong>28,600</strong></td>
+        <td>28,919</td>
+      </tr>
+      <tr>
+        <td>Revenue from Government</td>
+        <td></td>
+        <td><strong>30,525</strong></td>
+        <td>28,641</td>
+      </tr>
+      <tr>
+        <td colspan="2"><em><strong>Surplus/(Deficit) attributable to the Australian Government</strong></em></td>
+        <td><strong>1,925</strong></td>
+        <td>(278)</td>
+      </tr>
+      <tr>
+        <td><strong>OTHER COMPREHENSIVE INCOME</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>Items not subject to subsequent reclassification to net cost of services</strong></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Changes in asset revaluation surplus</td>
+        <td></td>
+        <td><strong>-</strong></td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td><em><strong>Total comprehensive income/(loss) attributable to the Australian Government</strong></em></td>
+        <td></td>
+        <td><strong>1,925</strong></td>
+        <td>(278)</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<div class="notes indented">
   <div markdown="1">
 **Budget Variance Commentary**
 

--- a/pages/who-we-are/corporate/annual-report-15-16/05-references.md
+++ b/pages/who-we-are/corporate/annual-report-15-16/05-references.md
@@ -46,314 +46,315 @@ doc-nav:
  </dl>
 
 {% include hx.html lvl=2 text="List of requirements" %}
-
-<table class="content-table" summary="List of requirements">
-  <colgroup>
-  <col />
-  <col />
-  </colgroup>
-  <thead>
-    <tr>
-      <th width="80%"><p>Description</p></th>
-      <th width="20%"><p>Requirement met</p></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/cover-letter/#letter-of-transmittal">Letter of transmittal</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-    <td><a href="/who-we-are/corporate/annual-report/2015-16/cover-letter/">Table of contents</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td>Index</td>
-      <td>Yes, on print version</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/references/#glossary-and-abbreviations-list">List of abbreviations and acronyms</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/references/#list-of-requirements">List of reporting requirements</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-    <td><a href="/who-we-are/corporate/annual-report/2015-16/cover-letter">Contact officer(s)</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/cover-letter">Website and internet address for report</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-    <td><strong><em>Chief Executive Officer’s review</em></strong></td>
-      <td />
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/1-introduction/#chief-executive-officers-review">Review by accountable authority</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td>Significant issues and developments—portfolio</td>
-      <td>Not applicable</td>
-    </tr>
-    <tr>
-    <td><strong><em>Overview</em></strong></td>
-      <td />
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/1-introduction/#overview">Role and functions</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/1-introduction/#organisational-structure">Organisational structure</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/1-introduction/#outcome-and-program-structure">Outcome and program structure</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/2-program-performance/#purpose">Purposes</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td>Portfolio structure</td>
-      <td>Not applicable</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/1-introduction/#about-this-report">Where outcome and program structure differs from Portfolio Budget Statements, Portfolio Additional Estimates Statements or other portfolio statements accompanying any other additional appropriation bills, details of variation and reasons for change</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-    <td><strong><em>Annual performance statements</em></strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/2-program-performance/#annual-performance-statements">Annual performance statements in accordance with paragraph 39(1)(b) of the <em>Public Governance, Performance and Accountability Act 2013</em> (PGPA Act)</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-    <td><strong><em>Report on financial performance</em></strong></td>
-      <td />
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/2-program-performance/#report-on-financial-performance">Discussion and analysis of the entity’s financial performance</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/2-program-performance/#report-on-financial-performance">Tables summarising the total resources and total payments of the entity</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/2-program-performance/#report-on-financial-performance">Discussion of any significant changes in financial results during or after the previous or current reporting period</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-    <td><strong><em>Management and accountability</em></strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><em>Corporate governance</em></td>
-      <td />
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/cover-letter/#letter-of-transmittal">Information on compliance with section 10 of the PGPA Act</a> (<a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#fraud-prevention-and-control">fraud systems</a>)</td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/cover-letter/#letter-of-transmittal">Certification by accountable authority that fraud risk assessments and fraud control plans have been prepared</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/cover-letter/#letter-of-transmittal">Certification by accountable authority that appropriate mechanisms for preventing, detecting incidents of, investigating or otherwise dealing with, and recording or reporting fraud that meet the specific needs of the entity are in place</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/cover-letter/#letter-of-transmittal">Certification by accountable authority that all reasonable measures have been taken to deal appropriately with fraud relating to the entity</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#corporate-governance">Statement of the main corporate governance practices in place</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#significant-issues-of-non-compliance">A statement of significant issues reported to the minister under paragraph 19(1)(e) of the PGPA Act that relates to non-compliance with the finance law and action taken to remedy non-compliance</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><em>External scrutiny</em></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#external-scrutiny">Significant developments in external scrutiny</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#external-scrutiny">Judicial decisions and decisions of administrative tribunals and by the Australian Information Commissioner</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#external-scrutiny">Reports by the Auditor-General, a parliamentary committee, the Commonwealth Ombudsman or an agency capability review</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><em>Management of human resources</em></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#management-of-human-resources">Assessment of effectiveness in managing and developing employees to achieve objectives</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-    <td><em>Statistics on staffing</em></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#employment-arrangements">Enterprise or collective agreements, individual flexibility arrangements, Australian workplace agreements, common law contracts and determinations under subsection 24(1) of the <em>Public Service Act 1999</em></a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#employment-arrangements">Numbers of Senior Executive Service (SES) and non-SES employees covered by agreements</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#employment-arrangements">Salary ranges available for Australian Public Service employees by classification</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#employment-arrangements">Non-salary benefits provided to employees</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#employment-arrangements">Information on the number of employees at each classification level who received performance pay</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td>Information on aggregate amounts of performance pay at each classification level</td>
-      <td>Not applicable</td>
-    </tr>
-    <tr>
-      <td>Information on the average amount of performance payment, and range of such payments, at each classification level</td>
-      <td>Not applicable</td>
-    </tr>
-    <tr>
-      <td>Information on aggregate amount of performance payments</td>
-      <td>Not applicable</td>
-    </tr>
-    <tr>
-      <td><em>Assets management</em></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Assessment of effectiveness of assets management </td>
-      <td>Not applicable</td>
-    </tr>
-    <tr>
-      <td><em>Purchasing</em></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#purchasing-and-procurement">Assessment of performance against the Commonwealth Procurement Rules</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><em>Consultants</em></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#consultancies">A summary statement detailing the number of new contracts engaging consultants entered into during the period, the total actual expenditure on all new consultancy contracts entered into during the period (inclusive of GST), the number of ongoing consultancy contracts that were entered into during a previous reporting period, and the total actual expenditure in the reporting year on the ongoing consultancy contracts (inclusive of GST)</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#consultancies">Prescribed statement on numbers and value of new and ongoing contracts</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#consultancies">A summary of policies and procedures for selecting and engaging consultants, and the main purposes for which consultants were engaged</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#consultancies">Prescribed statement noting that information on contracts and consultancies is available through the AusTender website</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><em>Australian National Audit Office access clauses</em></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#purchasing-and-procurement">Absence of provisions in contracts allowing access by the Auditor-General</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><em>Exempt contracts</em></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#purchasing-and-procurement">Contracts exempted from publication on AusTender</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><em>Small business</em></td>
-      <td />
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#purchasing-and-procurement">Prescribed statement on support for small business participation</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#purchasing-and-procurement">Procurement practices to support small and medium enterprises</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#purchasing-and-procurement">Prescribed statement of recognition for small business by material entities</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-    <td><strong><em>Financial statements</em></strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/4-financial-statements/">Financial statements</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-    <td><strong><em>Other mandatory information</em></strong></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#advertising-and-market-research">Advertising and market research (section 311A of the <em>Commonwealth Electoral Act 1918</em>) and statement on advertising campaigns</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td>Statement on grants</td>
-      <td>Not applicable</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#disability">Outline of the mechanisms of disability reporting</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#freedom-of-information">Reference to web address of Information Publication Scheme statement</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td>Correction of material errors in previous annual report</td>
-      <td>Not applicable</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#work-health-and-safety">Work health and safety (Schedule 2, Part 4 of the <em>Work Health and Safety Act 2011</em>)</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#environmental-performance">Ecologically sustainable development and environmental performance (section 516A of the <em>Environment Protection and Biodiversity Conservation Act 1999</em>)</a></td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td>Compliance with obligations under the <em>Carer Recognition Act 2010</em></td>
-      <td>Not applicable</td>
-    </tr>
-  </tbody>
-</table>
+<div class="horizontal-scroll-table-container">
+  <table class="content-table" summary="List of requirements">
+    <colgroup>
+    <col />
+    <col />
+    </colgroup>
+    <thead>
+      <tr>
+        <th width="80%"><p>Description</p></th>
+        <th width="20%"><p>Requirement met</p></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/cover-letter/#letter-of-transmittal">Letter of transmittal</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+      <td><a href="/who-we-are/corporate/annual-report/2015-16/cover-letter/">Table of contents</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>Index</td>
+        <td>Yes, on print version</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/references/#glossary-and-abbreviations-list">List of abbreviations and acronyms</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/references/#list-of-requirements">List of reporting requirements</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+      <td><a href="/who-we-are/corporate/annual-report/2015-16/cover-letter">Contact officer(s)</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/cover-letter">Website and internet address for report</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+      <td><strong><em>Chief Executive Officer’s review</em></strong></td>
+        <td />
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/1-introduction/#chief-executive-officers-review">Review by accountable authority</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>Significant issues and developments—portfolio</td>
+        <td>Not applicable</td>
+      </tr>
+      <tr>
+      <td><strong><em>Overview</em></strong></td>
+        <td />
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/1-introduction/#overview">Role and functions</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/1-introduction/#organisational-structure">Organisational structure</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/1-introduction/#outcome-and-program-structure">Outcome and program structure</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/2-program-performance/#purpose">Purposes</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>Portfolio structure</td>
+        <td>Not applicable</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/1-introduction/#about-this-report">Where outcome and program structure differs from Portfolio Budget Statements, Portfolio Additional Estimates Statements or other portfolio statements accompanying any other additional appropriation bills, details of variation and reasons for change</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+      <td><strong><em>Annual performance statements</em></strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/2-program-performance/#annual-performance-statements">Annual performance statements in accordance with paragraph 39(1)(b) of the <em>Public Governance, Performance and Accountability Act 2013</em> (PGPA Act)</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+      <td><strong><em>Report on financial performance</em></strong></td>
+        <td />
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/2-program-performance/#report-on-financial-performance">Discussion and analysis of the entity’s financial performance</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/2-program-performance/#report-on-financial-performance">Tables summarising the total resources and total payments of the entity</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/2-program-performance/#report-on-financial-performance">Discussion of any significant changes in financial results during or after the previous or current reporting period</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+      <td><strong><em>Management and accountability</em></strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><em>Corporate governance</em></td>
+        <td />
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/cover-letter/#letter-of-transmittal">Information on compliance with section 10 of the PGPA Act</a> (<a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#fraud-prevention-and-control">fraud systems</a>)</td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/cover-letter/#letter-of-transmittal">Certification by accountable authority that fraud risk assessments and fraud control plans have been prepared</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/cover-letter/#letter-of-transmittal">Certification by accountable authority that appropriate mechanisms for preventing, detecting incidents of, investigating or otherwise dealing with, and recording or reporting fraud that meet the specific needs of the entity are in place</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/cover-letter/#letter-of-transmittal">Certification by accountable authority that all reasonable measures have been taken to deal appropriately with fraud relating to the entity</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#corporate-governance">Statement of the main corporate governance practices in place</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#significant-issues-of-non-compliance">A statement of significant issues reported to the minister under paragraph 19(1)(e) of the PGPA Act that relates to non-compliance with the finance law and action taken to remedy non-compliance</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><em>External scrutiny</em></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#external-scrutiny">Significant developments in external scrutiny</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#external-scrutiny">Judicial decisions and decisions of administrative tribunals and by the Australian Information Commissioner</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#external-scrutiny">Reports by the Auditor-General, a parliamentary committee, the Commonwealth Ombudsman or an agency capability review</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><em>Management of human resources</em></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#management-of-human-resources">Assessment of effectiveness in managing and developing employees to achieve objectives</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+      <td><em>Statistics on staffing</em></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#employment-arrangements">Enterprise or collective agreements, individual flexibility arrangements, Australian workplace agreements, common law contracts and determinations under subsection 24(1) of the <em>Public Service Act 1999</em></a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#employment-arrangements">Numbers of Senior Executive Service (SES) and non-SES employees covered by agreements</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#employment-arrangements">Salary ranges available for Australian Public Service employees by classification</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#employment-arrangements">Non-salary benefits provided to employees</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#employment-arrangements">Information on the number of employees at each classification level who received performance pay</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>Information on aggregate amounts of performance pay at each classification level</td>
+        <td>Not applicable</td>
+      </tr>
+      <tr>
+        <td>Information on the average amount of performance payment, and range of such payments, at each classification level</td>
+        <td>Not applicable</td>
+      </tr>
+      <tr>
+        <td>Information on aggregate amount of performance payments</td>
+        <td>Not applicable</td>
+      </tr>
+      <tr>
+        <td><em>Assets management</em></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Assessment of effectiveness of assets management </td>
+        <td>Not applicable</td>
+      </tr>
+      <tr>
+        <td><em>Purchasing</em></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#purchasing-and-procurement">Assessment of performance against the Commonwealth Procurement Rules</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><em>Consultants</em></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#consultancies">A summary statement detailing the number of new contracts engaging consultants entered into during the period, the total actual expenditure on all new consultancy contracts entered into during the period (inclusive of GST), the number of ongoing consultancy contracts that were entered into during a previous reporting period, and the total actual expenditure in the reporting year on the ongoing consultancy contracts (inclusive of GST)</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#consultancies">Prescribed statement on numbers and value of new and ongoing contracts</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#consultancies">A summary of policies and procedures for selecting and engaging consultants, and the main purposes for which consultants were engaged</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#consultancies">Prescribed statement noting that information on contracts and consultancies is available through the AusTender website</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><em>Australian National Audit Office access clauses</em></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#purchasing-and-procurement">Absence of provisions in contracts allowing access by the Auditor-General</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><em>Exempt contracts</em></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#purchasing-and-procurement">Contracts exempted from publication on AusTender</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><em>Small business</em></td>
+        <td />
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#purchasing-and-procurement">Prescribed statement on support for small business participation</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#purchasing-and-procurement">Procurement practices to support small and medium enterprises</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#purchasing-and-procurement">Prescribed statement of recognition for small business by material entities</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+      <td><strong><em>Financial statements</em></strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/4-financial-statements/">Financial statements</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+      <td><strong><em>Other mandatory information</em></strong></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#advertising-and-market-research">Advertising and market research (section 311A of the <em>Commonwealth Electoral Act 1918</em>) and statement on advertising campaigns</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>Statement on grants</td>
+        <td>Not applicable</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#disability">Outline of the mechanisms of disability reporting</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#freedom-of-information">Reference to web address of Information Publication Scheme statement</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>Correction of material errors in previous annual report</td>
+        <td>Not applicable</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#work-health-and-safety">Work health and safety (Schedule 2, Part 4 of the <em>Work Health and Safety Act 2011</em>)</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><a href="/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/#environmental-performance">Ecologically sustainable development and environmental performance (section 516A of the <em>Environment Protection and Biodiversity Conservation Act 1999</em>)</a></td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>Compliance with obligations under the <em>Carer Recognition Act 2010</em></td>
+        <td>Not applicable</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/pages/who-we-are/corporate/annual-report-15-16/text-versions/4-appropriations-table.md
+++ b/pages/who-we-are/corporate/annual-report-15-16/text-versions/4-appropriations-table.md
@@ -6,6 +6,6 @@ searchexcerpt: "Annual Report 2015-16 Financial Statements Notes 3.1 Appropriati
 ---
 [&larr; Back to Annual Report 2015-16 financial statements notes](/who-we-are/corporate/annual-report/2015-16/4-financial-statements/#appropriations)
 
-{% include annual-report/3.1-appropriations-tables.html %}
+{% include annual-report/3.1-appropriations-tables.html no-scroll=1%}
 
 [&larr; Back to Annual Report 2015-16 financial statements notes](/who-we-are/corporate/annual-report/2015-16/4-financial-statements/#appropriations)

--- a/pages/who-we-are/corporate/annual-report-15-16/text-versions/4-appropriations-table.md
+++ b/pages/who-we-are/corporate/annual-report-15-16/text-versions/4-appropriations-table.md
@@ -1,9 +1,11 @@
 ---
-title: Financial statement notes — appropriations 
+title: Financial statement notes — appropriations tables
 layout: fullscreen
 permalink: /who-we-are/corporate/annual-report/2015-16/4-financial-statements/appropriations-table/
-searchexcerpt: "Annual Report 2015-16 Financial Statements Notes 3.1 Appropriations"
+searchexcerpt: "Annual Report 2015-16 Financial Statements notes — 3.1 Appropriations tables"
 ---
+<h1>Annual Report 2015-16 Financial Statement notes — 3.1 Appropriations tables</h1>
+
 [&larr; Back to Annual Report 2015-16 financial statements notes](/who-we-are/corporate/annual-report/2015-16/4-financial-statements/#appropriations)
 
 {% include annual-report/3.1-appropriations-tables.html no-scroll=1%}


### PR DESCRIPTION
Breaking out some of the changes for the annual report in #243.

Wraps all tables except for Table 1 in a div with overflow:auto so the tables are still readable at mobile, albeit with scrolling.
H/T to @TrebBrennan.

I recommend ignoring whitespace when reviewing this PR -  [?w=1 link](https://github.com/AusDTO/dta-website/pull/328/files?w=1)

Preview links:
[Section 2](https://1401-71211972-gh.circle-artifacts.com/0/home/ubuntu/dta-website/_site/who-we-are/corporate/annual-report/2015-16/2-program-performance/index.html)
[Section 3](https://1401-71211972-gh.circle-artifacts.com/0/home/ubuntu/dta-website/_site/who-we-are/corporate/annual-report/2015-16/3-organisational-performance/index.html)
[Section 4](https://1401-71211972-gh.circle-artifacts.com/0/home/ubuntu/dta-website/_site/who-we-are/corporate/annual-report/2015-16/4-financial-statements/index.html)

I think the biggest issue is that the table title can also be half cut off and need scrolling to view: (at mobile):
![image](https://cloud.githubusercontent.com/assets/2324569/22957412/2cbf258c-f37c-11e6-99fe-724b13cc2c65.png)

It's also not ideal how sometimes there's no visual cue that the user can scroll.

