### PR TITLE
Remove duplicate adjacent links

### DIFF
--- a/_assets/scss/main.scss
+++ b/_assets/scss/main.scss
@@ -56,6 +56,7 @@ $live: #859949;
 @import 'partials/our-work-page';
 @import 'partials/homepage';
 @import 'partials/icons';
+@import 'partials/latest-post-list';
 @import 'partials/recruiterbox';
 @import 'partials/transformation-agenda';
 @import 'partials/signup';

--- a/_assets/scss/partials/_homepage.scss
+++ b/_assets/scss/partials/_homepage.scss
@@ -27,17 +27,6 @@
       padding-top: 0;
     }
   }
-
-  div.meta {
-    display: inline-block;
-    padding-top: $small-spacing;
-    time {
-      display: inline-block;
-    }
-    a {
-      margin-left: $tiny-spacing;
-    }
-  }
 }
 
 .what-we-do {

--- a/_assets/scss/partials/_latest-post-list.scss
+++ b/_assets/scss/partials/_latest-post-list.scss
@@ -1,0 +1,37 @@
+.latest-post-list {
+  a {
+    border-bottom: initial;
+    &:hover {
+      background-color: initial;
+    }
+
+    img {
+      margin-bottom: $tiny-spacing;
+    }
+    h3 {
+      margin-bottom: 0;
+      span {
+        border-bottom: solid 1px $light-aqua;
+        &:hover {
+          background-color: $light-aqua;
+        }
+      }
+    }
+  }
+
+  div.meta {
+    display: inline-block;
+    padding-top: $small-spacing;
+    order: initial;
+    time {
+      display: inline-block;
+    }
+    a {
+      margin-left: $tiny-spacing;
+      border-bottom: solid 1px $light-aqua;
+      &:hover {
+        background-color: $light-aqua;
+      }
+    }
+  }
+}

--- a/_assets/scss/partials/_transformation-agenda.scss
+++ b/_assets/scss/partials/_transformation-agenda.scss
@@ -1,4 +1,3 @@
-
 .transformation-agenda {
   .index-links {
     h2 {
@@ -6,8 +5,9 @@
       font-weight: $base-font-weight;
     }
   }
+  // Fix font size bug from .govspeak
   .list-vertical--thirds {
-    h4 {
+    h3, h4 {
       font-size: rem(18);
       margin-top: 0;
       @include ie-lte(8) {
@@ -24,27 +24,4 @@
       background-color: initial;
     }
   }
-
-  .latest-news {
-    h3,
-    div,
-    p {
-      flex: 0 0 100%;
-      font-size: rem(18);
-      margin-top: 0;
-    }
-    div.meta {
-      display: inline-block;
-      padding-top: $small-spacing;
-      time {
-        display: inline-block;
-      }
-      .tags {
-        margin-left: $tiny-spacing;
-      }
-    }
-
-  }
-
 }
-

--- a/_includes/latest-post-list-item.html
+++ b/_includes/latest-post-list-item.html
@@ -1,0 +1,40 @@
+<li>
+  <article>
+    <a href="{{ url }}">
+      <figure>
+        {% if include.post.thumbnail %}
+        <img class="blog-thumbnail" src="{{site.baseurl}}{{ include.post.thumbnail }}" alt="">
+        {% else %}
+        <img class="blog-thumbnail" src="{{site.baseurl}}/images/post-thumbnail-placeholder.png" alt="">
+        {% endif %}
+      </figure>
+      <h3><span>{{ include.post.title }}</span></h3>
+    </a>
+    <div class="meta">
+      <time datetime="{{ post.date }}">{{ include.post.date | date: "%-d %b %Y" }}</time>
+      {% if include.show-category %}
+        {% if include.post.category contains "blog" %}
+      <a href="{{site.baseurl}}/blog/">Blog</a>
+        {% else %}
+      <a href="{{site.baseurl}}/news/">News</a>
+        {% endif %}
+      {% endif %}
+      {% if include.show-author %}
+      <div class="author">{{ include.post.author }}</div>
+      {% endif %}
+    </div>
+
+    {% if include.show-tags and include.post.tags.size > 0 %}
+    <footer class="tags">
+      <dl>
+        <dt>Tags:</dt>
+        {% for tag in include.post.tags %}
+          {% if tag != '' %}
+          <dd><a href="{{site.baseurl}}{{site.tag_dir}}/{{tag | slugify }}/" >{{tag}}</a></dd>
+          {% endif %}
+        {% endfor %}
+      </dl>
+    </footer>
+    {% endif %}
+  </article>
+</li>

--- a/_includes/post-list-item.html
+++ b/_includes/post-list-item.html
@@ -1,15 +1,12 @@
-
+<li>
 {% assign url = post.url %}
 {% if post.external-url %}
   {% assign url = post.external-url%}
 {% endif %}
 
 <figure>
-
 {% if post.thumbnail %}
-  <a href="{{ url }}">
-    <img src="{{ post.thumbnail }}" alt="Read post {{ post.title }}" />
-  </a>
+  <img src="{{site.baseurl}}{{ post.thumbnail }}" alt="" />
 {% endif %}
 </figure>
 <article>
@@ -39,3 +36,4 @@
   </footer>
 {% endif %}
 </article>
+</li>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -12,7 +12,7 @@ layout: base
 
   <section class="news-media">
     <h2 class="home-heading">Latest news and blog posts</h2>
-    <ul class="list-vertical--fourths">
+    <ul class="list-vertical--fourths latest-post-list">
 
       {% for post in site.posts limit:8 %}
         {% assign url = post.url %}
@@ -20,29 +20,8 @@ layout: base
           {% assign url = post.external-url%}
         {% endif %}
 
-      <li>
-        <figure>
-          {% if post.thumbnail %}
-          <a href="{{ url }}"><img class="blog-thumbnail" src="{{site.baseurl}}{{ post.thumbnail }}" alt="Read post {{ post.title }}"></a>
-          {% else %}
-          <a href="{{ url }}"><img class="blog-thumbnail" src="{{site.baseurl}}/images/post-thumbnail-placeholder.png" alt="Read post {{ post.title }}"></a>
-          {% endif %}
-        </figure>
-        <article>
-          <h3>
-            <a href="{{ url }}">{{ post.title }}</a>
-          </h3>
-          <div class="meta">
-            <time datetime="{{ post.date }}">{{ post.date | date: "%-d %b %Y" }}</time>
-            {% if post.category contains "blog" %}
-            <a href="{{site.baseurl}}/blog/">Blog</a>
-            {% else %}
-            <a href="{{site.baseurl}}/news/">News</a>
-            {% endif %}
-            </span>
-          </div>
-        </article>
-      </li>
+      {% include latest-post-list-item.html post=post show-category=1 %}
+
       {% endfor %}
     </ul>
     <p><a class="see-more" href="/news/">See more news</a></p>

--- a/_layouts/tag-archive.html
+++ b/_layouts/tag-archive.html
@@ -32,13 +32,9 @@ searchexcerpt: "Browse our posts by topic"
   <p>Archived news from the Digital Transformation Office.</p>
   {% endif %}
   <ul class="list-horizontal">
-
     {% for post in page.posts %}
-    <li>
       {% include post-list-item.html %}
-    </li>
     {% endfor %}
-
   </ul>
   {% endif %}
 </article>

--- a/pages/blog/all-posts/index.html
+++ b/pages/blog/all-posts/index.html
@@ -5,8 +5,6 @@ permalink: /blog/all-posts/
 ---
 <ul class="list-horizontal">
 {% for post in site.categories['blog'] %}
-  <li>
-    {% include post-list-item.html %}
-  </li>
+  {% include post-list-item.html %}
 {% endfor %}
 </ul>

--- a/pages/blog/index.html
+++ b/pages/blog/index.html
@@ -11,41 +11,9 @@ permalink: /blog/
   <h1>Blog</h1>
   <h2>Latest blog posts</h2>
 
-  <ul class="list-vertical">
+  <ul class="list-vertical latest-post-list">
     {% for post in site.categories['blog'] limit:4 %}
-    <li>
-      <figure>
-        {% if post.thumbnail %}
-        <a href="{{ post.url }}"><img class="blog-thumbnail" src="{{ site.baseurl }}{{ post.thumbnail }}" alt="Read post {{ post.title }}"></a>
-        {% else %}
-        <a href="{{ post.url }}"><img class="blog-thumbnail" src="{{ site.baseurl }}/images/blog-thumbnail-placeholder.png" alt="Read post {{ post.title }}"></a>
-        {% endif %}
-      </figure>
-      <article>
-        <h3>
-          <a href="{{ post.url }}">{{ post.title }}</a>
-        </h3>
-        <div class="meta">
-          <time datetime="{{ post.date }}">{{ post.date | date: "%-d %b %Y" }}</time>
-          {{ post.author }}
-          <span class="tags">
-
-          </span>
-        </div>
-        {% if post.tags.size > 0 %}
-        <footer class="tags">
-          <dl>
-            <dt>Tags:</dt>
-            {% for tag in post.tags %}
-            {% if tag != '' %}
-            <dd><a href="{{site.baseurl}}{{site.tag_dir}}/{{tag | slugify }}/" >{{tag}}</a></dd>
-            {% endif %}
-            {% endfor %}
-          </dl>
-        </footer>
-        {% endif %}
-      </article>
-    </li>
+      {% include latest-post-list-item.html post=post show-tags=1 show-author=1%}
     {% endfor %}
   </ul>
 
@@ -66,8 +34,6 @@ permalink: /blog/
     {%endunless%}
     {% endfor %}
   </ul>
-
-
 
 </article>
 

--- a/pages/news/all/index.html
+++ b/pages/news/all/index.html
@@ -16,9 +16,7 @@ searchexcerpt: All the news from the Digital Transformation Agency.
         {% endif %}
     {% endfor %}
 
-    {% for post in news %}
-    <li>
-        {% include post-list-item.html %}
-    </li>
-    {% endfor %}
+  {% for post in news %}
+    {% include post-list-item.html %}
+  {% endfor %}
 </ul>

--- a/pages/news/index.html
+++ b/pages/news/index.html
@@ -20,9 +20,7 @@ redirect_from: /news/media-releases/
   {% endfor %}
 
   {% for post in news limit:3 %}
-  <li>
     {% include post-list-item.html %}
-  </li>
   {% endfor %}
 </ul>
 <p>

--- a/pages/what-we-do/transformation-agenda/transformation-agenda.md
+++ b/pages/what-we-do/transformation-agenda/transformation-agenda.md
@@ -138,35 +138,14 @@ Having problems seeing this image? [Open larger roadmap image]({{site.baseurl}}/
 
 ## Related news and blog posts
 
-<ul class="list-vertical--thirds latest-news">
+<ul class="list-vertical--thirds latest-post-list">
 
 {% for tag in site.tags %}
   {% assign t = tag | first %}
   {% if t == 'digital transformation' %}
     {% assign posts = tag | last %}
     {% for post in posts limit:3 %}
-    <li>
-      <figure>
-        {% if post.thumbnail %}
-        <a href="{{ post.url }}"><img class="blog-thumbnail" src="{{ site.baseurl }}{{ post.thumbnail }}" alt="Read post {{ post.title }}"></a>
-        {% else %}
-        <a href="{{ post.url }}"><img class="blog-thumbnail" src="{{ site.baseurl }}/images/post-thumbnail-placeholder.png" alt="Read post {{ post.title }}"></a>
-        {% endif %}
-      </figure>
-      <article>
-        <h3>
-          <a href="{{ post.url }}">{{ post.title }}</a>
-        </h3>
-        <div class="meta">
-          <time datetime="{{ post.date }}">{{ post.date | date: "%-d %b %Y" }}</time>
-          {% if post.category contains "blog" %}
-          <a href="{{site.baseurl}}/blog/">Blog</a>
-          {% else %}
-          <a href="{{site.baseurl}}/news/">News</a>
-          {% endif %}
-        </div>
-      </article>
-    </li>
+    {% include latest-post-list-item.html post=post show-category=1 %}
     {% endfor %}
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
This PR addresses issue [2] from the accessibility review - two adjacent links to the same destination was redundant and confusing for screen reader users. 

I have:
- merged the two links into one on the home page and /blog/
- removed the link on the image for the /blog/all and /news lists

Preview links:
Home page https://1467-71211972-gh.circle-artifacts.com/0/home/ubuntu/dta-website/_site/index.html
/blogs https://1467-71211972-gh.circle-artifacts.com/0/home/ubuntu/dta-website/_site/blog/index.html
/blog/all-posts - https://1467-71211972-gh.circle-artifacts.com/0/home/ubuntu/dta-website/_site/blog/all-posts/index.html

Closes #275 