### PR TITLE
Add div around <a> to fix in IE11

### DIFF
--- a/_includes/latest-post-list-item.html
+++ b/_includes/latest-post-list-item.html
@@ -4,16 +4,18 @@
 {% endif %}
 <li>
   <article>
-    <a href="{{ url }}">
-      <figure>
-        {% if include.post.thumbnail %}
-        <img class="blog-thumbnail" src="{{site.baseurl}}{{ include.post.thumbnail }}" alt="">
-        {% else %}
-        <img class="blog-thumbnail" src="{{site.baseurl}}/images/post-thumbnail-placeholder.png" alt="">
-        {% endif %}
-      </figure>
-      <h3><span>{{ include.post.title }}</span></h3>
-    </a>
+    <div>
+      <a href="{{ url }}">
+        <figure>
+          {% if include.post.thumbnail %}
+          <img class="blog-thumbnail" src="{{site.baseurl}}{{ include.post.thumbnail }}" alt="">
+          {% else %}
+          <img class="blog-thumbnail" src="{{site.baseurl}}/images/post-thumbnail-placeholder.png" alt="">
+          {% endif %}
+        </figure>
+        <h3><span>{{ include.post.title }}</span></h3>
+      </a>
+    </div>
     <div class="meta">
       <time datetime="{{ post.date }}">{{ include.post.date | date: "%-d %b %Y" }}</time>
       {% if include.show-category %}


### PR DESCRIPTION
Currently the homepage has some layout issues on IE11:
![dta-screenshot](https://cloud.githubusercontent.com/assets/2324569/23689252/8dac8b4a-040d-11e7-8926-7e14df856821.jpg)
This PR fixes the overflow.
https://1620-71211972-gh.circle-artifacts.com/0/home/ubuntu/dta-website/_site/index.html