### PR TITLE
Add aria-describedby attribute for validation error labels on sign-up form

### DIFF
--- a/_assets/js/vendor/mc-validate.js
+++ b/_assets/js/vendor/mc-validate.js
@@ -3970,7 +3970,11 @@
             },
             showLabel: function(b, c) {
                 var d = this.errorsFor(b);
-                d.length ? (d.removeClass(this.settings.validClass).addClass(this.settings.errorClass), d.html(c)) : (d = a("<" + this.settings.errorElement + ">").attr("for", this.idOrName(b)).addClass(this.settings.errorClass).html(c || ""), this.settings.wrapper && (d = d.hide().show().wrap("<" + this.settings.wrapper + "/>").parent()), this.labelContainer.append(d).length || (this.settings.errorPlacement ? this.settings.errorPlacement(d, a(b)) : d.insertAfter(b))), !c && this.settings.success && (d.text(""), "string" == typeof this.settings.success ? d.addClass(this.settings.success) : this.settings.success(d, b)), this.toShow = this.toShow.add(d)
+                d.length ? (d.removeClass(this.settings.validClass).addClass(this.settings.errorClass), d.html(c)) : (d = a("<" + this.settings.errorElement + ">").attr("for", this.idOrName(b)).addClass(this.settings.errorClass).html(c || ""), this.settings.wrapper && (d = d.hide().show().wrap("<" + this.settings.wrapper + "/>").parent()), this.labelContainer.append(d).length || (this.settings.errorPlacement ? this.settings.errorPlacement(d, a(b)) : d.insertAfter(b))), !c && this.settings.success && (d.text(""), "string" == typeof this.settings.success ? d.addClass(this.settings.success) : this.settings.success(d, b)),
+                    // DTA HOTFIX - added aria-describedby attribute
+                    d.attr("id",this.idOrName(b) + "-ERROR"),
+                    b.setAttribute("aria-describedby", d.attr("id")),
+                    this.toShow = this.toShow.add(d)
             },
             errorsFor: function(b) {
                 var c = this.idOrName(b);

--- a/_assets/js/vendor/mc-validate.js
+++ b/_assets/js/vendor/mc-validate.js
@@ -1,0 +1,4582 @@
+/*! jQuery v1.9.0 | (c) 2005, 2012 jQuery Foundation, Inc. | jquery.org/license */
+(function(e, t) {
+    "use strict";
+
+    function n(e) {
+        var t = e.length,
+            n = st.type(e);
+        return st.isWindow(e) ? !1 : 1 === e.nodeType && t ? !0 : "array" === n || "function" !== n && (0 === t || "number" == typeof t && t > 0 && t - 1 in e)
+    }
+
+    function r(e) {
+        var t = Tt[e] = {};
+        return st.each(e.match(lt) || [], function(e, n) {
+            t[n] = !0
+        }), t
+    }
+
+    function i(e, n, r, i) {
+        if (st.acceptData(e)) {
+            var o, a, s = st.expando,
+                u = "string" == typeof n,
+                l = e.nodeType,
+                c = l ? st.cache : e,
+                f = l ? e[s] : e[s] && s;
+            if (f && c[f] && (i || c[f].data) || !u || r !== t) return f || (l ? e[s] = f = K.pop() || st.guid++ : f = s), c[f] || (c[f] = {}, l || (c[f].toJSON = st.noop)), ("object" == typeof n || "function" == typeof n) && (i ? c[f] = st.extend(c[f], n) : c[f].data = st.extend(c[f].data, n)), o = c[f], i || (o.data || (o.data = {}), o = o.data), r !== t && (o[st.camelCase(n)] = r), u ? (a = o[n], null == a && (a = o[st.camelCase(n)])) : a = o, a
+        }
+    }
+
+    function o(e, t, n) {
+        if (st.acceptData(e)) {
+            var r, i, o, a = e.nodeType,
+                u = a ? st.cache : e,
+                l = a ? e[st.expando] : st.expando;
+            if (u[l]) {
+                if (t && (r = n ? u[l] : u[l].data)) {
+                    st.isArray(t) ? t = t.concat(st.map(t, st.camelCase)) : t in r ? t = [t] : (t = st.camelCase(t), t = t in r ? [t] : t.split(" "));
+                    for (i = 0, o = t.length; o > i; i++) delete r[t[i]];
+                    if (!(n ? s : st.isEmptyObject)(r)) return
+                }(n || (delete u[l].data, s(u[l]))) && (a ? st.cleanData([e], !0) : st.support.deleteExpando || u != u.window ? delete u[l] : u[l] = null)
+            }
+        }
+    }
+
+    function a(e, n, r) {
+        if (r === t && 1 === e.nodeType) {
+            var i = "data-" + n.replace(Nt, "-$1").toLowerCase();
+            if (r = e.getAttribute(i), "string" == typeof r) {
+                try {
+                    r = "true" === r ? !0 : "false" === r ? !1 : "null" === r ? null : +r + "" === r ? +r : wt.test(r) ? st.parseJSON(r) : r
+                } catch (o) {}
+                st.data(e, n, r)
+            } else r = t
+        }
+        return r
+    }
+
+    function s(e) {
+        var t;
+        for (t in e)
+            if (("data" !== t || !st.isEmptyObject(e[t])) && "toJSON" !== t) return !1;
+        return !0
+    }
+
+    function u() {
+        return !0
+    }
+
+    function l() {
+        return !1
+    }
+
+    function c(e, t) {
+        do e = e[t]; while (e && 1 !== e.nodeType);
+        return e
+    }
+
+    function f(e, t, n) {
+        if (t = t || 0, st.isFunction(t)) return st.grep(e, function(e, r) {
+            var i = !!t.call(e, r, e);
+            return i === n
+        });
+        if (t.nodeType) return st.grep(e, function(e) {
+            return e === t === n
+        });
+        if ("string" == typeof t) {
+            var r = st.grep(e, function(e) {
+                return 1 === e.nodeType
+            });
+            if (Wt.test(t)) return st.filter(t, r, !n);
+            t = st.filter(t, r)
+        }
+        return st.grep(e, function(e) {
+            return st.inArray(e, t) >= 0 === n
+        })
+    }
+
+    function p(e) {
+        var t = zt.split("|"),
+            n = e.createDocumentFragment();
+        if (n.createElement)
+            for (; t.length;) n.createElement(t.pop());
+        return n
+    }
+
+    function d(e, t) {
+        return e.getElementsByTagName(t)[0] || e.appendChild(e.ownerDocument.createElement(t))
+    }
+
+    function h(e) {
+        var t = e.getAttributeNode("type");
+        return e.type = (t && t.specified) + "/" + e.type, e
+    }
+
+    function g(e) {
+        var t = nn.exec(e.type);
+        return t ? e.type = t[1] : e.removeAttribute("type"), e
+    }
+
+    function m(e, t) {
+        for (var n, r = 0; null != (n = e[r]); r++) st._data(n, "globalEval", !t || st._data(t[r], "globalEval"))
+    }
+
+    function y(e, t) {
+        if (1 === t.nodeType && st.hasData(e)) {
+            var n, r, i, o = st._data(e),
+                a = st._data(t, o),
+                s = o.events;
+            if (s) {
+                delete a.handle, a.events = {};
+                for (n in s)
+                    for (r = 0, i = s[n].length; i > r; r++) st.event.add(t, n, s[n][r])
+            }
+            a.data && (a.data = st.extend({}, a.data))
+        }
+    }
+
+    function v(e, t) {
+        var n, r, i;
+        if (1 === t.nodeType) {
+            if (n = t.nodeName.toLowerCase(), !st.support.noCloneEvent && t[st.expando]) {
+                r = st._data(t);
+                for (i in r.events) st.removeEvent(t, i, r.handle);
+                t.removeAttribute(st.expando)
+            }
+            "script" === n && t.text !== e.text ? (h(t).text = e.text, g(t)) : "object" === n ? (t.parentNode && (t.outerHTML = e.outerHTML), st.support.html5Clone && e.innerHTML && !st.trim(t.innerHTML) && (t.innerHTML = e.innerHTML)) : "input" === n && Zt.test(e.type) ? (t.defaultChecked = t.checked = e.checked, t.value !== e.value && (t.value = e.value)) : "option" === n ? t.defaultSelected = t.selected = e.defaultSelected : ("input" === n || "textarea" === n) && (t.defaultValue = e.defaultValue)
+        }
+    }
+
+    function b(e, n) {
+        var r, i, o = 0,
+            a = e.getElementsByTagName !== t ? e.getElementsByTagName(n || "*") : e.querySelectorAll !== t ? e.querySelectorAll(n || "*") : t;
+        if (!a)
+            for (a = [], r = e.childNodes || e; null != (i = r[o]); o++) !n || st.nodeName(i, n) ? a.push(i) : st.merge(a, b(i, n));
+        return n === t || n && st.nodeName(e, n) ? st.merge([e], a) : a
+    }
+
+    function x(e) {
+        Zt.test(e.type) && (e.defaultChecked = e.checked)
+    }
+
+    function T(e, t) {
+        if (t in e) return t;
+        for (var n = t.charAt(0).toUpperCase() + t.slice(1), r = t, i = Nn.length; i--;)
+            if (t = Nn[i] + n, t in e) return t;
+        return r
+    }
+
+    function w(e, t) {
+        return e = t || e, "none" === st.css(e, "display") || !st.contains(e.ownerDocument, e)
+    }
+
+    function N(e, t) {
+        for (var n, r = [], i = 0, o = e.length; o > i; i++) n = e[i], n.style && (r[i] = st._data(n, "olddisplay"), t ? (r[i] || "none" !== n.style.display || (n.style.display = ""), "" === n.style.display && w(n) && (r[i] = st._data(n, "olddisplay", S(n.nodeName)))) : r[i] || w(n) || st._data(n, "olddisplay", st.css(n, "display")));
+        for (i = 0; o > i; i++) n = e[i], n.style && (t && "none" !== n.style.display && "" !== n.style.display || (n.style.display = t ? r[i] || "" : "none"));
+        return e
+    }
+
+    function C(e, t, n) {
+        var r = mn.exec(t);
+        return r ? Math.max(0, r[1] - (n || 0)) + (r[2] || "px") : t
+    }
+
+    function k(e, t, n, r, i) {
+        for (var o = n === (r ? "border" : "content") ? 4 : "width" === t ? 1 : 0, a = 0; 4 > o; o += 2) "margin" === n && (a += st.css(e, n + wn[o], !0, i)), r ? ("content" === n && (a -= st.css(e, "padding" + wn[o], !0, i)), "margin" !== n && (a -= st.css(e, "border" + wn[o] + "Width", !0, i))) : (a += st.css(e, "padding" + wn[o], !0, i), "padding" !== n && (a += st.css(e, "border" + wn[o] + "Width", !0, i)));
+        return a
+    }
+
+    function E(e, t, n) {
+        var r = !0,
+            i = "width" === t ? e.offsetWidth : e.offsetHeight,
+            o = ln(e),
+            a = st.support.boxSizing && "border-box" === st.css(e, "boxSizing", !1, o);
+        if (0 >= i || null == i) {
+            if (i = un(e, t, o), (0 > i || null == i) && (i = e.style[t]), yn.test(i)) return i;
+            r = a && (st.support.boxSizingReliable || i === e.style[t]), i = parseFloat(i) || 0
+        }
+        return i + k(e, t, n || (a ? "border" : "content"), r, o) + "px"
+    }
+
+    function S(e) {
+        var t = V,
+            n = bn[e];
+        return n || (n = A(e, t), "none" !== n && n || (cn = (cn || st("<iframe frameborder='0' width='0' height='0'/>").css("cssText", "display:block !important")).appendTo(t.documentElement), t = (cn[0].contentWindow || cn[0].contentDocument).document, t.write("<!doctype html><html><body>"), t.close(), n = A(e, t), cn.detach()), bn[e] = n), n
+    }
+
+    function A(e, t) {
+        var n = st(t.createElement(e)).appendTo(t.body),
+            r = st.css(n[0], "display");
+        return n.remove(), r
+    }
+
+    function j(e, t, n, r) {
+        var i;
+        if (st.isArray(t)) st.each(t, function(t, i) {
+            n || kn.test(e) ? r(e, i) : j(e + "[" + ("object" == typeof i ? t : "") + "]", i, n, r)
+        });
+        else if (n || "object" !== st.type(t)) r(e, t);
+        else
+            for (i in t) j(e + "[" + i + "]", t[i], n, r)
+    }
+
+    function D(e) {
+        return function(t, n) {
+            "string" != typeof t && (n = t, t = "*");
+            var r, i = 0,
+                o = t.toLowerCase().match(lt) || [];
+            if (st.isFunction(n))
+                for (; r = o[i++];) "+" === r[0] ? (r = r.slice(1) || "*", (e[r] = e[r] || []).unshift(n)) : (e[r] = e[r] || []).push(n)
+        }
+    }
+
+    function L(e, n, r, i) {
+        function o(u) {
+            var l;
+            return a[u] = !0, st.each(e[u] || [], function(e, u) {
+                var c = u(n, r, i);
+                return "string" != typeof c || s || a[c] ? s ? !(l = c) : t : (n.dataTypes.unshift(c), o(c), !1)
+            }), l
+        }
+        var a = {},
+            s = e === $n;
+        return o(n.dataTypes[0]) || !a["*"] && o("*")
+    }
+
+    function H(e, n) {
+        var r, i, o = st.ajaxSettings.flatOptions || {};
+        for (r in n) n[r] !== t && ((o[r] ? e : i || (i = {}))[r] = n[r]);
+        return i && st.extend(!0, e, i), e
+    }
+
+    function M(e, n, r) {
+        var i, o, a, s, u = e.contents,
+            l = e.dataTypes,
+            c = e.responseFields;
+        for (o in c) o in r && (n[c[o]] = r[o]);
+        for (;
+            "*" === l[0];) l.shift(), i === t && (i = e.mimeType || n.getResponseHeader("Content-Type"));
+        if (i)
+            for (o in u)
+                if (u[o] && u[o].test(i)) {
+                    l.unshift(o);
+                    break
+                }
+        if (l[0] in r) a = l[0];
+        else {
+            for (o in r) {
+                if (!l[0] || e.converters[o + " " + l[0]]) {
+                    a = o;
+                    break
+                }
+                s || (s = o)
+            }
+            a = a || s
+        }
+        return a ? (a !== l[0] && l.unshift(a), r[a]) : t
+    }
+
+    function q(e, t) {
+        var n, r, i, o, a = {},
+            s = 0,
+            u = e.dataTypes.slice(),
+            l = u[0];
+        if (e.dataFilter && (t = e.dataFilter(t, e.dataType)), u[1])
+            for (n in e.converters) a[n.toLowerCase()] = e.converters[n];
+        for (; i = u[++s];)
+            if ("*" !== i) {
+                if ("*" !== l && l !== i) {
+                    if (n = a[l + " " + i] || a["* " + i], !n)
+                        for (r in a)
+                            if (o = r.split(" "), o[1] === i && (n = a[l + " " + o[0]] || a["* " + o[0]])) {
+                                n === !0 ? n = a[r] : a[r] !== !0 && (i = o[0], u.splice(s--, 0, i));
+                                break
+                            }
+                    if (n !== !0)
+                        if (n && e["throws"]) t = n(t);
+                        else try {
+                            t = n(t)
+                        } catch (c) {
+                            return {
+                                state: "parsererror",
+                                error: n ? c : "No conversion from " + l + " to " + i
+                            }
+                        }
+                }
+                l = i
+            }
+        return {
+            state: "success",
+            data: t
+        }
+    }
+
+    function _() {
+        try {
+            return new e.XMLHttpRequest
+        } catch (t) {}
+    }
+
+    function F() {
+        try {
+            return new e.ActiveXObject("Microsoft.XMLHTTP")
+        } catch (t) {}
+    }
+
+    function O() {
+        return setTimeout(function() {
+            Qn = t
+        }), Qn = st.now()
+    }
+
+    function B(e, t) {
+        st.each(t, function(t, n) {
+            for (var r = (rr[t] || []).concat(rr["*"]), i = 0, o = r.length; o > i; i++)
+                if (r[i].call(e, t, n)) return
+        })
+    }
+
+    function P(e, t, n) {
+        var r, i, o = 0,
+            a = nr.length,
+            s = st.Deferred().always(function() {
+                delete u.elem
+            }),
+            u = function() {
+                if (i) return !1;
+                for (var t = Qn || O(), n = Math.max(0, l.startTime + l.duration - t), r = n / l.duration || 0, o = 1 - r, a = 0, u = l.tweens.length; u > a; a++) l.tweens[a].run(o);
+                return s.notifyWith(e, [l, o, n]), 1 > o && u ? n : (s.resolveWith(e, [l]), !1)
+            },
+            l = s.promise({
+                elem: e,
+                props: st.extend({}, t),
+                opts: st.extend(!0, {
+                    specialEasing: {}
+                }, n),
+                originalProperties: t,
+                originalOptions: n,
+                startTime: Qn || O(),
+                duration: n.duration,
+                tweens: [],
+                createTween: function(t, n) {
+                    var r = st.Tween(e, l.opts, t, n, l.opts.specialEasing[t] || l.opts.easing);
+                    return l.tweens.push(r), r
+                },
+                stop: function(t) {
+                    var n = 0,
+                        r = t ? l.tweens.length : 0;
+                    if (i) return this;
+                    for (i = !0; r > n; n++) l.tweens[n].run(1);
+                    return t ? s.resolveWith(e, [l, t]) : s.rejectWith(e, [l, t]), this
+                }
+            }),
+            c = l.props;
+        for (R(c, l.opts.specialEasing); a > o; o++)
+            if (r = nr[o].call(l, e, c, l.opts)) return r;
+        return B(l, c), st.isFunction(l.opts.start) && l.opts.start.call(e, l), st.fx.timer(st.extend(u, {
+            elem: e,
+            anim: l,
+            queue: l.opts.queue
+        })), l.progress(l.opts.progress).done(l.opts.done, l.opts.complete).fail(l.opts.fail).always(l.opts.always)
+    }
+
+    function R(e, t) {
+        var n, r, i, o, a;
+        for (n in e)
+            if (r = st.camelCase(n), i = t[r], o = e[n], st.isArray(o) && (i = o[1], o = e[n] = o[0]), n !== r && (e[r] = o, delete e[n]), a = st.cssHooks[r], a && "expand" in a) {
+                o = a.expand(o), delete e[r];
+                for (n in o) n in e || (e[n] = o[n], t[n] = i)
+            } else t[r] = i
+    }
+
+    function W(e, t, n) {
+        var r, i, o, a, s, u, l, c, f, p = this,
+            d = e.style,
+            h = {},
+            g = [],
+            m = e.nodeType && w(e);
+        n.queue || (c = st._queueHooks(e, "fx"), null == c.unqueued && (c.unqueued = 0, f = c.empty.fire, c.empty.fire = function() {
+            c.unqueued || f()
+        }), c.unqueued++, p.always(function() {
+            p.always(function() {
+                c.unqueued--, st.queue(e, "fx").length || c.empty.fire()
+            })
+        })), 1 === e.nodeType && ("height" in t || "width" in t) && (n.overflow = [d.overflow, d.overflowX, d.overflowY], "inline" === st.css(e, "display") && "none" === st.css(e, "float") && (st.support.inlineBlockNeedsLayout && "inline" !== S(e.nodeName) ? d.zoom = 1 : d.display = "inline-block")), n.overflow && (d.overflow = "hidden", st.support.shrinkWrapBlocks || p.done(function() {
+            d.overflow = n.overflow[0], d.overflowX = n.overflow[1], d.overflowY = n.overflow[2]
+        }));
+        for (r in t)
+            if (o = t[r], Zn.exec(o)) {
+                if (delete t[r], u = u || "toggle" === o, o === (m ? "hide" : "show")) continue;
+                g.push(r)
+            }
+        if (a = g.length) {
+            s = st._data(e, "fxshow") || st._data(e, "fxshow", {}), "hidden" in s && (m = s.hidden), u && (s.hidden = !m), m ? st(e).show() : p.done(function() {
+                    st(e).hide()
+                }), p.done(function() {
+                var t;
+                st._removeData(e, "fxshow");
+                for (t in h) st.style(e, t, h[t])
+            });
+            for (r = 0; a > r; r++) i = g[r], l = p.createTween(i, m ? s[i] : 0), h[i] = s[i] || st.style(e, i), i in s || (s[i] = l.start, m && (l.end = l.start, l.start = "width" === i || "height" === i ? 1 : 0))
+        }
+    }
+
+    function $(e, t, n, r, i) {
+        return new $.prototype.init(e, t, n, r, i)
+    }
+
+    function I(e, t) {
+        var n, r = {
+                height: e
+            },
+            i = 0;
+        for (t = t ? 1 : 0; 4 > i; i += 2 - t) n = wn[i], r["margin" + n] = r["padding" + n] = e;
+        return t && (r.opacity = r.width = e), r
+    }
+
+    function z(e) {
+        return st.isWindow(e) ? e : 9 === e.nodeType ? e.defaultView || e.parentWindow : !1
+    }
+    var X, U, V = e.document,
+        Y = e.location,
+        J = e.jQuery,
+        G = e.$,
+        Q = {},
+        K = [],
+        Z = "1.9.0",
+        et = K.concat,
+        tt = K.push,
+        nt = K.slice,
+        rt = K.indexOf,
+        it = Q.toString,
+        ot = Q.hasOwnProperty,
+        at = Z.trim,
+        st = function(e, t) {
+            return new st.fn.init(e, t, X)
+        },
+        ut = /[+-]?(?:\d*\.|)\d+(?:[eE][+-]?\d+|)/.source,
+        lt = /\S+/g,
+        ct = /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g,
+        ft = /^(?:(<[\w\W]+>)[^>]*|#([\w-]*))$/,
+        pt = /^<(\w+)\s*\/?>(?:<\/\1>|)$/,
+        dt = /^[\],:{}\s]*$/,
+        ht = /(?:^|:|,)(?:\s*\[)+/g,
+        gt = /\\(?:["\\\/bfnrt]|u[\da-fA-F]{4})/g,
+        mt = /"[^"\\\r\n]*"|true|false|null|-?(?:\d+\.|)\d+(?:[eE][+-]?\d+|)/g,
+        yt = /^-ms-/,
+        vt = /-([\da-z])/gi,
+        bt = function(e, t) {
+            return t.toUpperCase()
+        },
+        xt = function() {
+            V.addEventListener ? (V.removeEventListener("DOMContentLoaded", xt, !1), st.ready()) : "complete" === V.readyState && (V.detachEvent("onreadystatechange", xt), st.ready())
+        };
+    st.fn = st.prototype = {
+        jquery: Z,
+        constructor: st,
+        init: function(e, n, r) {
+            var i, o;
+            if (!e) return this;
+            if ("string" == typeof e) {
+                if (i = "<" === e.charAt(0) && ">" === e.charAt(e.length - 1) && e.length >= 3 ? [null, e, null] : ft.exec(e), !i || !i[1] && n) return !n || n.jquery ? (n || r).find(e) : this.constructor(n).find(e);
+                if (i[1]) {
+                    if (n = n instanceof st ? n[0] : n, st.merge(this, st.parseHTML(i[1], n && n.nodeType ? n.ownerDocument || n : V, !0)), pt.test(i[1]) && st.isPlainObject(n))
+                        for (i in n) st.isFunction(this[i]) ? this[i](n[i]) : this.attr(i, n[i]);
+                    return this
+                }
+                if (o = V.getElementById(i[2]), o && o.parentNode) {
+                    if (o.id !== i[2]) return r.find(e);
+                    this.length = 1, this[0] = o
+                }
+                return this.context = V, this.selector = e, this
+            }
+            return e.nodeType ? (this.context = this[0] = e, this.length = 1, this) : st.isFunction(e) ? r.ready(e) : (e.selector !== t && (this.selector = e.selector, this.context = e.context), st.makeArray(e, this))
+        },
+        selector: "",
+        length: 0,
+        size: function() {
+            return this.length
+        },
+        toArray: function() {
+            return nt.call(this)
+        },
+        get: function(e) {
+            return null == e ? this.toArray() : 0 > e ? this[this.length + e] : this[e]
+        },
+        pushStack: function(e) {
+            var t = st.merge(this.constructor(), e);
+            return t.prevObject = this, t.context = this.context, t
+        },
+        each: function(e, t) {
+            return st.each(this, e, t)
+        },
+        ready: function(e) {
+            return st.ready.promise().done(e), this
+        },
+        slice: function() {
+            return this.pushStack(nt.apply(this, arguments))
+        },
+        first: function() {
+            return this.eq(0)
+        },
+        last: function() {
+            return this.eq(-1)
+        },
+        eq: function(e) {
+            var t = this.length,
+                n = +e + (0 > e ? t : 0);
+            return this.pushStack(n >= 0 && t > n ? [this[n]] : [])
+        },
+        map: function(e) {
+            return this.pushStack(st.map(this, function(t, n) {
+                return e.call(t, n, t)
+            }))
+        },
+        end: function() {
+            return this.prevObject || this.constructor(null)
+        },
+        push: tt,
+        sort: [].sort,
+        splice: [].splice
+    }, st.fn.init.prototype = st.fn, st.extend = st.fn.extend = function() {
+        var e, n, r, i, o, a, s = arguments[0] || {},
+            u = 1,
+            l = arguments.length,
+            c = !1;
+        for ("boolean" == typeof s && (c = s, s = arguments[1] || {}, u = 2), "object" == typeof s || st.isFunction(s) || (s = {}), l === u && (s = this, --u); l > u; u++)
+            if (null != (e = arguments[u]))
+                for (n in e) r = s[n], i = e[n], s !== i && (c && i && (st.isPlainObject(i) || (o = st.isArray(i))) ? (o ? (o = !1, a = r && st.isArray(r) ? r : []) : a = r && st.isPlainObject(r) ? r : {}, s[n] = st.extend(c, a, i)) : i !== t && (s[n] = i));
+        return s
+    }, st.extend({
+        noConflict: function(t) {
+            return e.$ === st && (e.$ = G), t && e.jQuery === st && (e.jQuery = J), st
+        },
+        isReady: !1,
+        readyWait: 1,
+        holdReady: function(e) {
+            e ? st.readyWait++ : st.ready(!0)
+        },
+        ready: function(e) {
+            if (e === !0 ? !--st.readyWait : !st.isReady) {
+                if (!V.body) return setTimeout(st.ready);
+                st.isReady = !0, e !== !0 && --st.readyWait > 0 || (U.resolveWith(V, [st]), st.fn.trigger && st(V).trigger("ready").off("ready"))
+            }
+        },
+        isFunction: function(e) {
+            return "function" === st.type(e)
+        },
+        isArray: Array.isArray || function(e) {
+            return "array" === st.type(e)
+        },
+        isWindow: function(e) {
+            return null != e && e == e.window
+        },
+        isNumeric: function(e) {
+            return !isNaN(parseFloat(e)) && isFinite(e)
+        },
+        type: function(e) {
+            return null == e ? e + "" : "object" == typeof e || "function" == typeof e ? Q[it.call(e)] || "object" : typeof e
+        },
+        isPlainObject: function(e) {
+            if (!e || "object" !== st.type(e) || e.nodeType || st.isWindow(e)) return !1;
+            try {
+                if (e.constructor && !ot.call(e, "constructor") && !ot.call(e.constructor.prototype, "isPrototypeOf")) return !1
+            } catch (n) {
+                return !1
+            }
+            var r;
+            for (r in e);
+            return r === t || ot.call(e, r)
+        },
+        isEmptyObject: function(e) {
+            var t;
+            for (t in e) return !1;
+            return !0
+        },
+        error: function(e) {
+            throw Error(e)
+        },
+        parseHTML: function(e, t, n) {
+            if (!e || "string" != typeof e) return null;
+            "boolean" == typeof t && (n = t, t = !1), t = t || V;
+            var r = pt.exec(e),
+                i = !n && [];
+            return r ? [t.createElement(r[1])] : (r = st.buildFragment([e], t, i), i && st(i).remove(), st.merge([], r.childNodes))
+        },
+        parseJSON: function(n) {
+            return e.JSON && e.JSON.parse ? e.JSON.parse(n) : null === n ? n : "string" == typeof n && (n = st.trim(n), n && dt.test(n.replace(gt, "@").replace(mt, "]").replace(ht, ""))) ? Function("return " + n)() : (st.error("Invalid JSON: " + n), t)
+        },
+        parseXML: function(n) {
+            var r, i;
+            if (!n || "string" != typeof n) return null;
+            try {
+                e.DOMParser ? (i = new DOMParser, r = i.parseFromString(n, "text/xml")) : (r = new ActiveXObject("Microsoft.XMLDOM"), r.async = "false", r.loadXML(n))
+            } catch (o) {
+                r = t
+            }
+            return r && r.documentElement && !r.getElementsByTagName("parsererror").length || st.error("Invalid XML: " + n), r
+        },
+        noop: function() {},
+        globalEval: function(t) {
+            t && st.trim(t) && (e.execScript || function(t) {
+                e.eval.call(e, t)
+            })(t)
+        },
+        camelCase: function(e) {
+            return e.replace(yt, "ms-").replace(vt, bt)
+        },
+        nodeName: function(e, t) {
+            return e.nodeName && e.nodeName.toLowerCase() === t.toLowerCase()
+        },
+        each: function(e, t, r) {
+            var i, o = 0,
+                a = e.length,
+                s = n(e);
+            if (r) {
+                if (s)
+                    for (; a > o && (i = t.apply(e[o], r), i !== !1); o++);
+                else
+                    for (o in e)
+                        if (i = t.apply(e[o], r), i === !1) break
+            } else if (s)
+                for (; a > o && (i = t.call(e[o], o, e[o]), i !== !1); o++);
+            else
+                for (o in e)
+                    if (i = t.call(e[o], o, e[o]), i === !1) break; return e
+        },
+        trim: at && !at.call("\ufeff\u00a0") ? function(e) {
+                return null == e ? "" : at.call(e)
+            } : function(e) {
+                return null == e ? "" : (e + "").replace(ct, "")
+            },
+        makeArray: function(e, t) {
+            var r = t || [];
+            return null != e && (n(Object(e)) ? st.merge(r, "string" == typeof e ? [e] : e) : tt.call(r, e)), r
+        },
+        inArray: function(e, t, n) {
+            var r;
+            if (t) {
+                if (rt) return rt.call(t, e, n);
+                for (r = t.length, n = n ? 0 > n ? Math.max(0, r + n) : n : 0; r > n; n++)
+                    if (n in t && t[n] === e) return n
+            }
+            return -1
+        },
+        merge: function(e, n) {
+            var r = n.length,
+                i = e.length,
+                o = 0;
+            if ("number" == typeof r)
+                for (; r > o; o++) e[i++] = n[o];
+            else
+                for (; n[o] !== t;) e[i++] = n[o++];
+            return e.length = i, e
+        },
+        grep: function(e, t, n) {
+            var r, i = [],
+                o = 0,
+                a = e.length;
+            for (n = !!n; a > o; o++) r = !!t(e[o], o), n !== r && i.push(e[o]);
+            return i
+        },
+        map: function(e, t, r) {
+            var i, o = 0,
+                a = e.length,
+                s = n(e),
+                u = [];
+            if (s)
+                for (; a > o; o++) i = t(e[o], o, r), null != i && (u[u.length] = i);
+            else
+                for (o in e) i = t(e[o], o, r), null != i && (u[u.length] = i);
+            return et.apply([], u)
+        },
+        guid: 1,
+        proxy: function(e, n) {
+            var r, i, o;
+            return "string" == typeof n && (r = e[n], n = e, e = r), st.isFunction(e) ? (i = nt.call(arguments, 2), o = function() {
+                    return e.apply(n || this, i.concat(nt.call(arguments)))
+                }, o.guid = e.guid = e.guid || st.guid++, o) : t
+        },
+        access: function(e, n, r, i, o, a, s) {
+            var u = 0,
+                l = e.length,
+                c = null == r;
+            if ("object" === st.type(r)) {
+                o = !0;
+                for (u in r) st.access(e, n, u, r[u], !0, a, s)
+            } else if (i !== t && (o = !0, st.isFunction(i) || (s = !0), c && (s ? (n.call(e, i), n = null) : (c = n, n = function(e, t, n) {
+                        return c.call(st(e), n)
+                    })), n))
+                for (; l > u; u++) n(e[u], r, s ? i : i.call(e[u], u, n(e[u], r)));
+            return o ? e : c ? n.call(e) : l ? n(e[0], r) : a
+        },
+        now: function() {
+            return (new Date).getTime()
+        }
+    }), st.ready.promise = function(t) {
+        if (!U)
+            if (U = st.Deferred(), "complete" === V.readyState) setTimeout(st.ready);
+            else if (V.addEventListener) V.addEventListener("DOMContentLoaded", xt, !1), e.addEventListener("load", st.ready, !1);
+            else {
+                V.attachEvent("onreadystatechange", xt), e.attachEvent("onload", st.ready);
+                var n = !1;
+                try {
+                    n = null == e.frameElement && V.documentElement
+                } catch (r) {}
+                n && n.doScroll && function i() {
+                    if (!st.isReady) {
+                        try {
+                            n.doScroll("left")
+                        } catch (e) {
+                            return setTimeout(i, 50)
+                        }
+                        st.ready()
+                    }
+                }()
+            }
+        return U.promise(t)
+    }, st.each("Boolean Number String Function Array Date RegExp Object Error".split(" "), function(e, t) {
+        Q["[object " + t + "]"] = t.toLowerCase()
+    }), X = st(V);
+    var Tt = {};
+    st.Callbacks = function(e) {
+        e = "string" == typeof e ? Tt[e] || r(e) : st.extend({}, e);
+        var n, i, o, a, s, u, l = [],
+            c = !e.once && [],
+            f = function(t) {
+                for (n = e.memory && t, i = !0, u = a || 0, a = 0, s = l.length, o = !0; l && s > u; u++)
+                    if (l[u].apply(t[0], t[1]) === !1 && e.stopOnFalse) {
+                        n = !1;
+                        break
+                    }
+                o = !1, l && (c ? c.length && f(c.shift()) : n ? l = [] : p.disable())
+            },
+            p = {
+                add: function() {
+                    if (l) {
+                        var t = l.length;
+                        (function r(t) {
+                            st.each(t, function(t, n) {
+                                var i = st.type(n);
+                                "function" === i ? e.unique && p.has(n) || l.push(n) : n && n.length && "string" !== i && r(n)
+                            })
+                        })(arguments), o ? s = l.length : n && (a = t, f(n))
+                    }
+                    return this
+                },
+                remove: function() {
+                    return l && st.each(arguments, function(e, t) {
+                        for (var n;
+                             (n = st.inArray(t, l, n)) > -1;) l.splice(n, 1), o && (s >= n && s--, u >= n && u--)
+                    }), this
+                },
+                has: function(e) {
+                    return st.inArray(e, l) > -1
+                },
+                empty: function() {
+                    return l = [], this
+                },
+                disable: function() {
+                    return l = c = n = t, this
+                },
+                disabled: function() {
+                    return !l
+                },
+                lock: function() {
+                    return c = t, n || p.disable(), this
+                },
+                locked: function() {
+                    return !c
+                },
+                fireWith: function(e, t) {
+                    return t = t || [], t = [e, t.slice ? t.slice() : t], !l || i && !c || (o ? c.push(t) : f(t)), this
+                },
+                fire: function() {
+                    return p.fireWith(this, arguments), this
+                },
+                fired: function() {
+                    return !!i
+                }
+            };
+        return p
+    }, st.extend({
+        Deferred: function(e) {
+            var t = [
+                    ["resolve", "done", st.Callbacks("once memory"), "resolved"],
+                    ["reject", "fail", st.Callbacks("once memory"), "rejected"],
+                    ["notify", "progress", st.Callbacks("memory")]
+                ],
+                n = "pending",
+                r = {
+                    state: function() {
+                        return n
+                    },
+                    always: function() {
+                        return i.done(arguments).fail(arguments), this
+                    },
+                    then: function() {
+                        var e = arguments;
+                        return st.Deferred(function(n) {
+                            st.each(t, function(t, o) {
+                                var a = o[0],
+                                    s = st.isFunction(e[t]) && e[t];
+                                i[o[1]](function() {
+                                    var e = s && s.apply(this, arguments);
+                                    e && st.isFunction(e.promise) ? e.promise().done(n.resolve).fail(n.reject).progress(n.notify) : n[a + "With"](this === r ? n.promise() : this, s ? [e] : arguments)
+                                })
+                            }), e = null
+                        }).promise()
+                    },
+                    promise: function(e) {
+                        return null != e ? st.extend(e, r) : r
+                    }
+                },
+                i = {};
+            return r.pipe = r.then, st.each(t, function(e, o) {
+                var a = o[2],
+                    s = o[3];
+                r[o[1]] = a.add, s && a.add(function() {
+                    n = s
+                }, t[1 ^ e][2].disable, t[2][2].lock), i[o[0]] = function() {
+                    return i[o[0] + "With"](this === i ? r : this, arguments), this
+                }, i[o[0] + "With"] = a.fireWith
+            }), r.promise(i), e && e.call(i, i), i
+        },
+        when: function(e) {
+            var t, n, r, i = 0,
+                o = nt.call(arguments),
+                a = o.length,
+                s = 1 !== a || e && st.isFunction(e.promise) ? a : 0,
+                u = 1 === s ? e : st.Deferred(),
+                l = function(e, n, r) {
+                    return function(i) {
+                        n[e] = this, r[e] = arguments.length > 1 ? nt.call(arguments) : i, r === t ? u.notifyWith(n, r) : --s || u.resolveWith(n, r)
+                    }
+                };
+            if (a > 1)
+                for (t = Array(a), n = Array(a), r = Array(a); a > i; i++) o[i] && st.isFunction(o[i].promise) ? o[i].promise().done(l(i, r, o)).fail(u.reject).progress(l(i, n, t)) : --s;
+            return s || u.resolveWith(r, o), u.promise()
+        }
+    }), st.support = function() {
+        var n, r, i, o, a, s, u, l, c, f, p = V.createElement("div");
+        if (p.setAttribute("className", "t"), p.innerHTML = "  <link/><table></table><a href='/a'>a</a><input type='checkbox'/>", r = p.getElementsByTagName("*"), i = p.getElementsByTagName("a")[0], !r || !i || !r.length) return {};
+        o = V.createElement("select"), a = o.appendChild(V.createElement("option")), s = p.getElementsByTagName("input")[0], i.style.cssText = "top:1px;float:left;opacity:.5", n = {
+            getSetAttribute: "t" !== p.className,
+            leadingWhitespace: 3 === p.firstChild.nodeType,
+            tbody: !p.getElementsByTagName("tbody").length,
+            htmlSerialize: !!p.getElementsByTagName("link").length,
+            style: /top/.test(i.getAttribute("style")),
+            hrefNormalized: "/a" === i.getAttribute("href"),
+            opacity: /^0.5/.test(i.style.opacity),
+            cssFloat: !!i.style.cssFloat,
+            checkOn: !!s.value,
+            optSelected: a.selected,
+            enctype: !!V.createElement("form").enctype,
+            html5Clone: "<:nav></:nav>" !== V.createElement("nav").cloneNode(!0).outerHTML,
+            boxModel: "CSS1Compat" === V.compatMode,
+            deleteExpando: !0,
+            noCloneEvent: !0,
+            inlineBlockNeedsLayout: !1,
+            shrinkWrapBlocks: !1,
+            reliableMarginRight: !0,
+            boxSizingReliable: !0,
+            pixelPosition: !1
+        }, s.checked = !0, n.noCloneChecked = s.cloneNode(!0).checked, o.disabled = !0, n.optDisabled = !a.disabled;
+        try {
+            delete p.test
+        } catch (d) {
+            n.deleteExpando = !1
+        }
+        s = V.createElement("input"), s.setAttribute("value", ""), n.input = "" === s.getAttribute("value"), s.value = "t", s.setAttribute("type", "radio"), n.radioValue = "t" === s.value, s.setAttribute("checked", "t"), s.setAttribute("name", "t"), u = V.createDocumentFragment(), u.appendChild(s), n.appendChecked = s.checked, n.checkClone = u.cloneNode(!0).cloneNode(!0).lastChild.checked, p.attachEvent && (p.attachEvent("onclick", function() {
+            n.noCloneEvent = !1
+        }), p.cloneNode(!0).click());
+        for (f in {
+            submit: !0,
+            change: !0,
+            focusin: !0
+        }) p.setAttribute(l = "on" + f, "t"), n[f + "Bubbles"] = l in e || p.attributes[l].expando === !1;
+        return p.style.backgroundClip = "content-box", p.cloneNode(!0).style.backgroundClip = "", n.clearCloneStyle = "content-box" === p.style.backgroundClip, st(function() {
+            var r, i, o, a = "padding:0;margin:0;border:0;display:block;box-sizing:content-box;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;",
+                s = V.getElementsByTagName("body")[0];
+            s && (r = V.createElement("div"), r.style.cssText = "border:0;width:0;height:0;position:absolute;top:0;left:-9999px;margin-top:1px", s.appendChild(r).appendChild(p), p.innerHTML = "<table><tr><td></td><td>t</td></tr></table>", o = p.getElementsByTagName("td"), o[0].style.cssText = "padding:0;margin:0;border:0;display:none", c = 0 === o[0].offsetHeight, o[0].style.display = "", o[1].style.display = "none", n.reliableHiddenOffsets = c && 0 === o[0].offsetHeight, p.innerHTML = "", p.style.cssText = "box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;padding:1px;border:1px;display:block;width:4px;margin-top:1%;position:absolute;top:1%;", n.boxSizing = 4 === p.offsetWidth, n.doesNotIncludeMarginInBodyOffset = 1 !== s.offsetTop, e.getComputedStyle && (n.pixelPosition = "1%" !== (e.getComputedStyle(p, null) || {}).top, n.boxSizingReliable = "4px" === (e.getComputedStyle(p, null) || {
+                    width: "4px"
+                }).width, i = p.appendChild(V.createElement("div")), i.style.cssText = p.style.cssText = a, i.style.marginRight = i.style.width = "0", p.style.width = "1px", n.reliableMarginRight = !parseFloat((e.getComputedStyle(i, null) || {}).marginRight)), p.style.zoom !== t && (p.innerHTML = "", p.style.cssText = a + "width:1px;padding:1px;display:inline;zoom:1", n.inlineBlockNeedsLayout = 3 === p.offsetWidth, p.style.display = "block", p.innerHTML = "<div></div>", p.firstChild.style.width = "5px", n.shrinkWrapBlocks = 3 !== p.offsetWidth, s.style.zoom = 1), s.removeChild(r), r = p = o = i = null)
+        }), r = o = u = a = i = s = null, n
+    }();
+    var wt = /(?:\{[\s\S]*\}|\[[\s\S]*\])$/,
+        Nt = /([A-Z])/g;
+    st.extend({
+        cache: {},
+        expando: "jQuery" + (Z + Math.random()).replace(/\D/g, ""),
+        noData: {
+            embed: !0,
+            object: "clsid:D27CDB6E-AE6D-11cf-96B8-444553540000",
+            applet: !0
+        },
+        hasData: function(e) {
+            return e = e.nodeType ? st.cache[e[st.expando]] : e[st.expando], !!e && !s(e)
+        },
+        data: function(e, t, n) {
+            return i(e, t, n, !1)
+        },
+        removeData: function(e, t) {
+            return o(e, t, !1)
+        },
+        _data: function(e, t, n) {
+            return i(e, t, n, !0)
+        },
+        _removeData: function(e, t) {
+            return o(e, t, !0)
+        },
+        acceptData: function(e) {
+            var t = e.nodeName && st.noData[e.nodeName.toLowerCase()];
+            return !t || t !== !0 && e.getAttribute("classid") === t
+        }
+    }), st.fn.extend({
+        data: function(e, n) {
+            var r, i, o = this[0],
+                s = 0,
+                u = null;
+            if (e === t) {
+                if (this.length && (u = st.data(o), 1 === o.nodeType && !st._data(o, "parsedAttrs"))) {
+                    for (r = o.attributes; r.length > s; s++) i = r[s].name, i.indexOf("data-") || (i = st.camelCase(i.substring(5)), a(o, i, u[i]));
+                    st._data(o, "parsedAttrs", !0)
+                }
+                return u
+            }
+            return "object" == typeof e ? this.each(function() {
+                    st.data(this, e)
+                }) : st.access(this, function(n) {
+                    return n === t ? o ? a(o, e, st.data(o, e)) : null : (this.each(function() {
+                            st.data(this, e, n)
+                        }), t)
+                }, null, n, arguments.length > 1, null, !0)
+        },
+        removeData: function(e) {
+            return this.each(function() {
+                st.removeData(this, e)
+            })
+        }
+    }), st.extend({
+        queue: function(e, n, r) {
+            var i;
+            return e ? (n = (n || "fx") + "queue", i = st._data(e, n), r && (!i || st.isArray(r) ? i = st._data(e, n, st.makeArray(r)) : i.push(r)), i || []) : t
+        },
+        dequeue: function(e, t) {
+            t = t || "fx";
+            var n = st.queue(e, t),
+                r = n.length,
+                i = n.shift(),
+                o = st._queueHooks(e, t),
+                a = function() {
+                    st.dequeue(e, t)
+                };
+            "inprogress" === i && (i = n.shift(), r--), o.cur = i, i && ("fx" === t && n.unshift("inprogress"), delete o.stop, i.call(e, a, o)), !r && o && o.empty.fire()
+        },
+        _queueHooks: function(e, t) {
+            var n = t + "queueHooks";
+            return st._data(e, n) || st._data(e, n, {
+                    empty: st.Callbacks("once memory").add(function() {
+                        st._removeData(e, t + "queue"), st._removeData(e, n)
+                    })
+                })
+        }
+    }), st.fn.extend({
+        queue: function(e, n) {
+            var r = 2;
+            return "string" != typeof e && (n = e, e = "fx", r--), r > arguments.length ? st.queue(this[0], e) : n === t ? this : this.each(function() {
+                        var t = st.queue(this, e, n);
+                        st._queueHooks(this, e), "fx" === e && "inprogress" !== t[0] && st.dequeue(this, e)
+                    })
+        },
+        dequeue: function(e) {
+            return this.each(function() {
+                st.dequeue(this, e)
+            })
+        },
+        delay: function(e, t) {
+            return e = st.fx ? st.fx.speeds[e] || e : e, t = t || "fx", this.queue(t, function(t, n) {
+                var r = setTimeout(t, e);
+                n.stop = function() {
+                    clearTimeout(r)
+                }
+            })
+        },
+        clearQueue: function(e) {
+            return this.queue(e || "fx", [])
+        },
+        promise: function(e, n) {
+            var r, i = 1,
+                o = st.Deferred(),
+                a = this,
+                s = this.length,
+                u = function() {
+                    --i || o.resolveWith(a, [a])
+                };
+            for ("string" != typeof e && (n = e, e = t), e = e || "fx"; s--;) r = st._data(a[s], e + "queueHooks"), r && r.empty && (i++, r.empty.add(u));
+            return u(), o.promise(n)
+        }
+    });
+    var Ct, kt, Et = /[\t\r\n]/g,
+        St = /\r/g,
+        At = /^(?:input|select|textarea|button|object)$/i,
+        jt = /^(?:a|area)$/i,
+        Dt = /^(?:checked|selected|autofocus|autoplay|async|controls|defer|disabled|hidden|loop|multiple|open|readonly|required|scoped)$/i,
+        Lt = /^(?:checked|selected)$/i,
+        Ht = st.support.getSetAttribute,
+        Mt = st.support.input;
+    st.fn.extend({
+        attr: function(e, t) {
+            return st.access(this, st.attr, e, t, arguments.length > 1)
+        },
+        removeAttr: function(e) {
+            return this.each(function() {
+                st.removeAttr(this, e)
+            })
+        },
+        prop: function(e, t) {
+            return st.access(this, st.prop, e, t, arguments.length > 1)
+        },
+        removeProp: function(e) {
+            return e = st.propFix[e] || e, this.each(function() {
+                try {
+                    this[e] = t, delete this[e]
+                } catch (n) {}
+            })
+        },
+        addClass: function(e) {
+            var t, n, r, i, o, a = 0,
+                s = this.length,
+                u = "string" == typeof e && e;
+            if (st.isFunction(e)) return this.each(function(t) {
+                st(this).addClass(e.call(this, t, this.className))
+            });
+            if (u)
+                for (t = (e || "").match(lt) || []; s > a; a++)
+                    if (n = this[a], r = 1 === n.nodeType && (n.className ? (" " + n.className + " ").replace(Et, " ") : " ")) {
+                        for (o = 0; i = t[o++];) 0 > r.indexOf(" " + i + " ") && (r += i + " ");
+                        n.className = st.trim(r)
+                    }
+            return this
+        },
+        removeClass: function(e) {
+            var t, n, r, i, o, a = 0,
+                s = this.length,
+                u = 0 === arguments.length || "string" == typeof e && e;
+            if (st.isFunction(e)) return this.each(function(t) {
+                st(this).removeClass(e.call(this, t, this.className))
+            });
+            if (u)
+                for (t = (e || "").match(lt) || []; s > a; a++)
+                    if (n = this[a], r = 1 === n.nodeType && (n.className ? (" " + n.className + " ").replace(Et, " ") : "")) {
+                        for (o = 0; i = t[o++];)
+                            for (; r.indexOf(" " + i + " ") >= 0;) r = r.replace(" " + i + " ", " ");
+                        n.className = e ? st.trim(r) : ""
+                    }
+            return this
+        },
+        toggleClass: function(e, t) {
+            var n = typeof e,
+                r = "boolean" == typeof t;
+            return st.isFunction(e) ? this.each(function(n) {
+                    st(this).toggleClass(e.call(this, n, this.className, t), t)
+                }) : this.each(function() {
+                    if ("string" === n)
+                        for (var i, o = 0, a = st(this), s = t, u = e.match(lt) || []; i = u[o++];) s = r ? s : !a.hasClass(i), a[s ? "addClass" : "removeClass"](i);
+                    else("undefined" === n || "boolean" === n) && (this.className && st._data(this, "__className__", this.className), this.className = this.className || e === !1 ? "" : st._data(this, "__className__") || "")
+                })
+        },
+        hasClass: function(e) {
+            for (var t = " " + e + " ", n = 0, r = this.length; r > n; n++)
+                if (1 === this[n].nodeType && (" " + this[n].className + " ").replace(Et, " ").indexOf(t) >= 0) return !0;
+            return !1
+        },
+        val: function(e) {
+            var n, r, i, o = this[0]; {
+                if (arguments.length) return i = st.isFunction(e), this.each(function(r) {
+                    var o, a = st(this);
+                    1 === this.nodeType && (o = i ? e.call(this, r, a.val()) : e, null == o ? o = "" : "number" == typeof o ? o += "" : st.isArray(o) && (o = st.map(o, function(e) {
+                                return null == e ? "" : e + ""
+                            })), n = st.valHooks[this.type] || st.valHooks[this.nodeName.toLowerCase()], n && "set" in n && n.set(this, o, "value") !== t || (this.value = o))
+                });
+                if (o) return n = st.valHooks[o.type] || st.valHooks[o.nodeName.toLowerCase()], n && "get" in n && (r = n.get(o, "value")) !== t ? r : (r = o.value, "string" == typeof r ? r.replace(St, "") : null == r ? "" : r)
+            }
+        }
+    }), st.extend({
+        valHooks: {
+            option: {
+                get: function(e) {
+                    var t = e.attributes.value;
+                    return !t || t.specified ? e.value : e.text
+                }
+            },
+            select: {
+                get: function(e) {
+                    for (var t, n, r = e.options, i = e.selectedIndex, o = "select-one" === e.type || 0 > i, a = o ? null : [], s = o ? i + 1 : r.length, u = 0 > i ? s : o ? i : 0; s > u; u++)
+                        if (n = r[u], !(!n.selected && u !== i || (st.support.optDisabled ? n.disabled : null !== n.getAttribute("disabled")) || n.parentNode.disabled && st.nodeName(n.parentNode, "optgroup"))) {
+                            if (t = st(n).val(), o) return t;
+                            a.push(t)
+                        }
+                    return a
+                },
+                set: function(e, t) {
+                    var n = st.makeArray(t);
+                    return st(e).find("option").each(function() {
+                        this.selected = st.inArray(st(this).val(), n) >= 0
+                    }), n.length || (e.selectedIndex = -1), n
+                }
+            }
+        },
+        attr: function(e, n, r) {
+            var i, o, a, s = e.nodeType;
+            if (e && 3 !== s && 8 !== s && 2 !== s) return e.getAttribute === t ? st.prop(e, n, r) : (a = 1 !== s || !st.isXMLDoc(e), a && (n = n.toLowerCase(), o = st.attrHooks[n] || (Dt.test(n) ? kt : Ct)), r === t ? o && a && "get" in o && null !== (i = o.get(e, n)) ? i : (e.getAttribute !== t && (i = e.getAttribute(n)), null == i ? t : i) : null !== r ? o && a && "set" in o && (i = o.set(e, r, n)) !== t ? i : (e.setAttribute(n, r + ""), r) : (st.removeAttr(e, n), t))
+        },
+        removeAttr: function(e, t) {
+            var n, r, i = 0,
+                o = t && t.match(lt);
+            if (o && 1 === e.nodeType)
+                for (; n = o[i++];) r = st.propFix[n] || n, Dt.test(n) ? !Ht && Lt.test(n) ? e[st.camelCase("default-" + n)] = e[r] = !1 : e[r] = !1 : st.attr(e, n, ""), e.removeAttribute(Ht ? n : r)
+        },
+        attrHooks: {
+            type: {
+                set: function(e, t) {
+                    if (!st.support.radioValue && "radio" === t && st.nodeName(e, "input")) {
+                        var n = e.value;
+                        return e.setAttribute("type", t), n && (e.value = n), t
+                    }
+                }
+            }
+        },
+        propFix: {
+            tabindex: "tabIndex",
+            readonly: "readOnly",
+            "for": "htmlFor",
+            "class": "className",
+            maxlength: "maxLength",
+            cellspacing: "cellSpacing",
+            cellpadding: "cellPadding",
+            rowspan: "rowSpan",
+            colspan: "colSpan",
+            usemap: "useMap",
+            frameborder: "frameBorder",
+            contenteditable: "contentEditable"
+        },
+        prop: function(e, n, r) {
+            var i, o, a, s = e.nodeType;
+            if (e && 3 !== s && 8 !== s && 2 !== s) return a = 1 !== s || !st.isXMLDoc(e), a && (n = st.propFix[n] || n, o = st.propHooks[n]), r !== t ? o && "set" in o && (i = o.set(e, r, n)) !== t ? i : e[n] = r : o && "get" in o && null !== (i = o.get(e, n)) ? i : e[n]
+        },
+        propHooks: {
+            tabIndex: {
+                get: function(e) {
+                    var n = e.getAttributeNode("tabindex");
+                    return n && n.specified ? parseInt(n.value, 10) : At.test(e.nodeName) || jt.test(e.nodeName) && e.href ? 0 : t
+                }
+            }
+        }
+    }), kt = {
+        get: function(e, n) {
+            var r = st.prop(e, n),
+                i = "boolean" == typeof r && e.getAttribute(n),
+                o = "boolean" == typeof r ? Mt && Ht ? null != i : Lt.test(n) ? e[st.camelCase("default-" + n)] : !!i : e.getAttributeNode(n);
+            return o && o.value !== !1 ? n.toLowerCase() : t
+        },
+        set: function(e, t, n) {
+            return t === !1 ? st.removeAttr(e, n) : Mt && Ht || !Lt.test(n) ? e.setAttribute(!Ht && st.propFix[n] || n, n) : e[st.camelCase("default-" + n)] = e[n] = !0, n
+        }
+    }, Mt && Ht || (st.attrHooks.value = {
+        get: function(e, n) {
+            var r = e.getAttributeNode(n);
+            return st.nodeName(e, "input") ? e.defaultValue : r && r.specified ? r.value : t
+        },
+        set: function(e, n, r) {
+            return st.nodeName(e, "input") ? (e.defaultValue = n, t) : Ct && Ct.set(e, n, r)
+        }
+    }), Ht || (Ct = st.valHooks.button = {
+        get: function(e, n) {
+            var r = e.getAttributeNode(n);
+            return r && ("id" === n || "name" === n || "coords" === n ? "" !== r.value : r.specified) ? r.value : t
+        },
+        set: function(e, n, r) {
+            var i = e.getAttributeNode(r);
+            return i || e.setAttributeNode(i = e.ownerDocument.createAttribute(r)), i.value = n += "", "value" === r || n === e.getAttribute(r) ? n : t
+        }
+    }, st.attrHooks.contenteditable = {
+        get: Ct.get,
+        set: function(e, t, n) {
+            Ct.set(e, "" === t ? !1 : t, n)
+        }
+    }, st.each(["width", "height"], function(e, n) {
+        st.attrHooks[n] = st.extend(st.attrHooks[n], {
+            set: function(e, r) {
+                return "" === r ? (e.setAttribute(n, "auto"), r) : t
+            }
+        })
+    })), st.support.hrefNormalized || (st.each(["href", "src", "width", "height"], function(e, n) {
+        st.attrHooks[n] = st.extend(st.attrHooks[n], {
+            get: function(e) {
+                var r = e.getAttribute(n, 2);
+                return null == r ? t : r
+            }
+        })
+    }), st.each(["href", "src"], function(e, t) {
+        st.propHooks[t] = {
+            get: function(e) {
+                return e.getAttribute(t, 4)
+            }
+        }
+    })), st.support.style || (st.attrHooks.style = {
+        get: function(e) {
+            return e.style.cssText || t
+        },
+        set: function(e, t) {
+            return e.style.cssText = t + ""
+        }
+    }), st.support.optSelected || (st.propHooks.selected = st.extend(st.propHooks.selected, {
+        get: function(e) {
+            var t = e.parentNode;
+            return t && (t.selectedIndex, t.parentNode && t.parentNode.selectedIndex), null
+        }
+    })), st.support.enctype || (st.propFix.enctype = "encoding"), st.support.checkOn || st.each(["radio", "checkbox"], function() {
+        st.valHooks[this] = {
+            get: function(e) {
+                return null === e.getAttribute("value") ? "on" : e.value
+            }
+        }
+    }), st.each(["radio", "checkbox"], function() {
+        st.valHooks[this] = st.extend(st.valHooks[this], {
+            set: function(e, n) {
+                return st.isArray(n) ? e.checked = st.inArray(st(e).val(), n) >= 0 : t
+            }
+        })
+    });
+    var qt = /^(?:input|select|textarea)$/i,
+        _t = /^key/,
+        Ft = /^(?:mouse|contextmenu)|click/,
+        Ot = /^(?:focusinfocus|focusoutblur)$/,
+        Bt = /^([^.]*)(?:\.(.+)|)$/;
+    st.event = {
+        global: {},
+        add: function(e, n, r, i, o) {
+            var a, s, u, l, c, f, p, d, h, g, m, y = 3 !== e.nodeType && 8 !== e.nodeType && st._data(e);
+            if (y) {
+                for (r.handler && (a = r, r = a.handler, o = a.selector), r.guid || (r.guid = st.guid++), (l = y.events) || (l = y.events = {}), (s = y.handle) || (s = y.handle = function(e) {
+                    return st === t || e && st.event.triggered === e.type ? t : st.event.dispatch.apply(s.elem, arguments)
+                }, s.elem = e), n = (n || "").match(lt) || [""], c = n.length; c--;) u = Bt.exec(n[c]) || [], h = m = u[1], g = (u[2] || "").split(".").sort(), p = st.event.special[h] || {}, h = (o ? p.delegateType : p.bindType) || h, p = st.event.special[h] || {}, f = st.extend({
+                    type: h,
+                    origType: m,
+                    data: i,
+                    handler: r,
+                    guid: r.guid,
+                    selector: o,
+                    needsContext: o && st.expr.match.needsContext.test(o),
+                    namespace: g.join(".")
+                }, a), (d = l[h]) || (d = l[h] = [], d.delegateCount = 0, p.setup && p.setup.call(e, i, g, s) !== !1 || (e.addEventListener ? e.addEventListener(h, s, !1) : e.attachEvent && e.attachEvent("on" + h, s))), p.add && (p.add.call(e, f), f.handler.guid || (f.handler.guid = r.guid)), o ? d.splice(d.delegateCount++, 0, f) : d.push(f), st.event.global[h] = !0;
+                e = null
+            }
+        },
+        remove: function(e, t, n, r, i) {
+            var o, a, s, u, l, c, f, p, d, h, g, m = st.hasData(e) && st._data(e);
+            if (m && (u = m.events)) {
+                for (t = (t || "").match(lt) || [""], l = t.length; l--;)
+                    if (s = Bt.exec(t[l]) || [], d = g = s[1], h = (s[2] || "").split(".").sort(), d) {
+                        for (f = st.event.special[d] || {}, d = (r ? f.delegateType : f.bindType) || d, p = u[d] || [], s = s[2] && RegExp("(^|\\.)" + h.join("\\.(?:.*\\.|)") + "(\\.|$)"), a = o = p.length; o--;) c = p[o], !i && g !== c.origType || n && n.guid !== c.guid || s && !s.test(c.namespace) || r && r !== c.selector && ("**" !== r || !c.selector) || (p.splice(o, 1), c.selector && p.delegateCount--, f.remove && f.remove.call(e, c));
+                        a && !p.length && (f.teardown && f.teardown.call(e, h, m.handle) !== !1 || st.removeEvent(e, d, m.handle), delete u[d])
+                    } else
+                        for (d in u) st.event.remove(e, d + t[l], n, r, !0);
+                st.isEmptyObject(u) && (delete m.handle, st._removeData(e, "events"))
+            }
+        },
+        trigger: function(n, r, i, o) {
+            var a, s, u, l, c, f, p, d = [i || V],
+                h = n.type || n,
+                g = n.namespace ? n.namespace.split(".") : [];
+            if (s = u = i = i || V, 3 !== i.nodeType && 8 !== i.nodeType && !Ot.test(h + st.event.triggered) && (h.indexOf(".") >= 0 && (g = h.split("."), h = g.shift(), g.sort()), c = 0 > h.indexOf(":") && "on" + h, n = n[st.expando] ? n : new st.Event(h, "object" == typeof n && n), n.isTrigger = !0, n.namespace = g.join("."), n.namespace_re = n.namespace ? RegExp("(^|\\.)" + g.join("\\.(?:.*\\.|)") + "(\\.|$)") : null, n.result = t, n.target || (n.target = i), r = null == r ? [n] : st.makeArray(r, [n]), p = st.event.special[h] || {}, o || !p.trigger || p.trigger.apply(i, r) !== !1)) {
+                if (!o && !p.noBubble && !st.isWindow(i)) {
+                    for (l = p.delegateType || h, Ot.test(l + h) || (s = s.parentNode); s; s = s.parentNode) d.push(s), u = s;
+                    u === (i.ownerDocument || V) && d.push(u.defaultView || u.parentWindow || e)
+                }
+                for (a = 0;
+                     (s = d[a++]) && !n.isPropagationStopped();) n.type = a > 1 ? l : p.bindType || h, f = (st._data(s, "events") || {})[n.type] && st._data(s, "handle"), f && f.apply(s, r), f = c && s[c], f && st.acceptData(s) && f.apply && f.apply(s, r) === !1 && n.preventDefault();
+                if (n.type = h, !(o || n.isDefaultPrevented() || p._default && p._default.apply(i.ownerDocument, r) !== !1 || "click" === h && st.nodeName(i, "a") || !st.acceptData(i) || !c || !i[h] || st.isWindow(i))) {
+                    u = i[c], u && (i[c] = null), st.event.triggered = h;
+                    try {
+                        i[h]()
+                    } catch (m) {}
+                    st.event.triggered = t, u && (i[c] = u)
+                }
+                return n.result
+            }
+        },
+        dispatch: function(e) {
+            e = st.event.fix(e);
+            var n, r, i, o, a, s = [],
+                u = nt.call(arguments),
+                l = (st._data(this, "events") || {})[e.type] || [],
+                c = st.event.special[e.type] || {};
+            if (u[0] = e, e.delegateTarget = this, !c.preDispatch || c.preDispatch.call(this, e) !== !1) {
+                for (s = st.event.handlers.call(this, e, l), n = 0;
+                     (o = s[n++]) && !e.isPropagationStopped();)
+                    for (e.currentTarget = o.elem, r = 0;
+                         (a = o.handlers[r++]) && !e.isImmediatePropagationStopped();)(!e.namespace_re || e.namespace_re.test(a.namespace)) && (e.handleObj = a, e.data = a.data, i = ((st.event.special[a.origType] || {}).handle || a.handler).apply(o.elem, u), i !== t && (e.result = i) === !1 && (e.preventDefault(), e.stopPropagation()));
+                return c.postDispatch && c.postDispatch.call(this, e), e.result
+            }
+        },
+        handlers: function(e, n) {
+            var r, i, o, a, s = [],
+                u = n.delegateCount,
+                l = e.target;
+            if (u && l.nodeType && (!e.button || "click" !== e.type))
+                for (; l != this; l = l.parentNode || this)
+                    if (l.disabled !== !0 || "click" !== e.type) {
+                        for (i = [], r = 0; u > r; r++) a = n[r], o = a.selector + " ", i[o] === t && (i[o] = a.needsContext ? st(o, this).index(l) >= 0 : st.find(o, this, null, [l]).length), i[o] && i.push(a);
+                        i.length && s.push({
+                            elem: l,
+                            handlers: i
+                        })
+                    }
+            return n.length > u && s.push({
+                elem: this,
+                handlers: n.slice(u)
+            }), s
+        },
+        fix: function(e) {
+            if (e[st.expando]) return e;
+            var t, n, r = e,
+                i = st.event.fixHooks[e.type] || {},
+                o = i.props ? this.props.concat(i.props) : this.props;
+            for (e = new st.Event(r), t = o.length; t--;) n = o[t], e[n] = r[n];
+            return e.target || (e.target = r.srcElement || V), 3 === e.target.nodeType && (e.target = e.target.parentNode), e.metaKey = !!e.metaKey, i.filter ? i.filter(e, r) : e
+        },
+        props: "altKey bubbles cancelable ctrlKey currentTarget eventPhase metaKey relatedTarget shiftKey target timeStamp view which".split(" "),
+        fixHooks: {},
+        keyHooks: {
+            props: "char charCode key keyCode".split(" "),
+            filter: function(e, t) {
+                return null == e.which && (e.which = null != t.charCode ? t.charCode : t.keyCode), e
+            }
+        },
+        mouseHooks: {
+            props: "button buttons clientX clientY fromElement offsetX offsetY pageX pageY screenX screenY toElement".split(" "),
+            filter: function(e, n) {
+                var r, i, o, a = n.button,
+                    s = n.fromElement;
+                return null == e.pageX && null != n.clientX && (r = e.target.ownerDocument || V, i = r.documentElement, o = r.body, e.pageX = n.clientX + (i && i.scrollLeft || o && o.scrollLeft || 0) - (i && i.clientLeft || o && o.clientLeft || 0), e.pageY = n.clientY + (i && i.scrollTop || o && o.scrollTop || 0) - (i && i.clientTop || o && o.clientTop || 0)), !e.relatedTarget && s && (e.relatedTarget = s === e.target ? n.toElement : s), e.which || a === t || (e.which = 1 & a ? 1 : 2 & a ? 3 : 4 & a ? 2 : 0), e
+            }
+        },
+        special: {
+            load: {
+                noBubble: !0
+            },
+            click: {
+                trigger: function() {
+                    return st.nodeName(this, "input") && "checkbox" === this.type && this.click ? (this.click(), !1) : t
+                }
+            },
+            focus: {
+                trigger: function() {
+                    if (this !== V.activeElement && this.focus) try {
+                        return this.focus(), !1
+                    } catch (e) {}
+                },
+                delegateType: "focusin"
+            },
+            blur: {
+                trigger: function() {
+                    return this === V.activeElement && this.blur ? (this.blur(), !1) : t
+                },
+                delegateType: "focusout"
+            },
+            beforeunload: {
+                postDispatch: function(e) {
+                    e.result !== t && (e.originalEvent.returnValue = e.result)
+                }
+            }
+        },
+        simulate: function(e, t, n, r) {
+            var i = st.extend(new st.Event, n, {
+                type: e,
+                isSimulated: !0,
+                originalEvent: {}
+            });
+            r ? st.event.trigger(i, null, t) : st.event.dispatch.call(t, i), i.isDefaultPrevented() && n.preventDefault()
+        }
+    }, st.removeEvent = V.removeEventListener ? function(e, t, n) {
+            e.removeEventListener && e.removeEventListener(t, n, !1)
+        } : function(e, n, r) {
+            var i = "on" + n;
+            e.detachEvent && (e[i] === t && (e[i] = null), e.detachEvent(i, r))
+        }, st.Event = function(e, n) {
+        return this instanceof st.Event ? (e && e.type ? (this.originalEvent = e, this.type = e.type, this.isDefaultPrevented = e.defaultPrevented || e.returnValue === !1 || e.getPreventDefault && e.getPreventDefault() ? u : l) : this.type = e, n && st.extend(this, n), this.timeStamp = e && e.timeStamp || st.now(), this[st.expando] = !0, t) : new st.Event(e, n)
+    }, st.Event.prototype = {
+        isDefaultPrevented: l,
+        isPropagationStopped: l,
+        isImmediatePropagationStopped: l,
+        preventDefault: function() {
+            var e = this.originalEvent;
+            this.isDefaultPrevented = u, e && (e.preventDefault ? e.preventDefault() : e.returnValue = !1)
+        },
+        stopPropagation: function() {
+            var e = this.originalEvent;
+            this.isPropagationStopped = u, e && (e.stopPropagation && e.stopPropagation(), e.cancelBubble = !0)
+        },
+        stopImmediatePropagation: function() {
+            this.isImmediatePropagationStopped = u, this.stopPropagation()
+        }
+    }, st.each({
+        mouseenter: "mouseover",
+        mouseleave: "mouseout"
+    }, function(e, t) {
+        st.event.special[e] = {
+            delegateType: t,
+            bindType: t,
+            handle: function(e) {
+                var n, r = this,
+                    i = e.relatedTarget,
+                    o = e.handleObj;
+                return (!i || i !== r && !st.contains(r, i)) && (e.type = o.origType, n = o.handler.apply(this, arguments), e.type = t), n
+            }
+        }
+    }), st.support.submitBubbles || (st.event.special.submit = {
+        setup: function() {
+            return st.nodeName(this, "form") ? !1 : (st.event.add(this, "click._submit keypress._submit", function(e) {
+                    var n = e.target,
+                        r = st.nodeName(n, "input") || st.nodeName(n, "button") ? n.form : t;
+                    r && !st._data(r, "submitBubbles") && (st.event.add(r, "submit._submit", function(e) {
+                        e._submit_bubble = !0
+                    }), st._data(r, "submitBubbles", !0))
+                }), t)
+        },
+        postDispatch: function(e) {
+            e._submit_bubble && (delete e._submit_bubble, this.parentNode && !e.isTrigger && st.event.simulate("submit", this.parentNode, e, !0))
+        },
+        teardown: function() {
+            return st.nodeName(this, "form") ? !1 : (st.event.remove(this, "._submit"), t)
+        }
+    }), st.support.changeBubbles || (st.event.special.change = {
+        setup: function() {
+            return qt.test(this.nodeName) ? (("checkbox" === this.type || "radio" === this.type) && (st.event.add(this, "propertychange._change", function(e) {
+                    "checked" === e.originalEvent.propertyName && (this._just_changed = !0)
+                }), st.event.add(this, "click._change", function(e) {
+                    this._just_changed && !e.isTrigger && (this._just_changed = !1), st.event.simulate("change", this, e, !0)
+                })), !1) : (st.event.add(this, "beforeactivate._change", function(e) {
+                    var t = e.target;
+                    qt.test(t.nodeName) && !st._data(t, "changeBubbles") && (st.event.add(t, "change._change", function(e) {
+                        !this.parentNode || e.isSimulated || e.isTrigger || st.event.simulate("change", this.parentNode, e, !0)
+                    }), st._data(t, "changeBubbles", !0))
+                }), t)
+        },
+        handle: function(e) {
+            var n = e.target;
+            return this !== n || e.isSimulated || e.isTrigger || "radio" !== n.type && "checkbox" !== n.type ? e.handleObj.handler.apply(this, arguments) : t
+        },
+        teardown: function() {
+            return st.event.remove(this, "._change"), !qt.test(this.nodeName)
+        }
+    }), st.support.focusinBubbles || st.each({
+        focus: "focusin",
+        blur: "focusout"
+    }, function(e, t) {
+        var n = 0,
+            r = function(e) {
+                st.event.simulate(t, e.target, st.event.fix(e), !0)
+            };
+        st.event.special[t] = {
+            setup: function() {
+                0 === n++ && V.addEventListener(e, r, !0)
+            },
+            teardown: function() {
+                0 === --n && V.removeEventListener(e, r, !0)
+            }
+        }
+    }), st.fn.extend({
+        on: function(e, n, r, i, o) {
+            var a, s;
+            if ("object" == typeof e) {
+                "string" != typeof n && (r = r || n, n = t);
+                for (s in e) this.on(s, n, r, e[s], o);
+                return this
+            }
+            if (null == r && null == i ? (i = n, r = n = t) : null == i && ("string" == typeof n ? (i = r, r = t) : (i = r, r = n, n = t)), i === !1) i = l;
+            else if (!i) return this;
+            return 1 === o && (a = i, i = function(e) {
+                return st().off(e), a.apply(this, arguments)
+            }, i.guid = a.guid || (a.guid = st.guid++)), this.each(function() {
+                st.event.add(this, e, i, r, n)
+            })
+        },
+        one: function(e, t, n, r) {
+            return this.on(e, t, n, r, 1)
+        },
+        off: function(e, n, r) {
+            var i, o;
+            if (e && e.preventDefault && e.handleObj) return i = e.handleObj, st(e.delegateTarget).off(i.namespace ? i.origType + "." + i.namespace : i.origType, i.selector, i.handler), this;
+            if ("object" == typeof e) {
+                for (o in e) this.off(o, n, e[o]);
+                return this
+            }
+            return (n === !1 || "function" == typeof n) && (r = n, n = t), r === !1 && (r = l), this.each(function() {
+                st.event.remove(this, e, r, n)
+            })
+        },
+        bind: function(e, t, n) {
+            return this.on(e, null, t, n)
+        },
+        unbind: function(e, t) {
+            return this.off(e, null, t)
+        },
+        delegate: function(e, t, n, r) {
+            return this.on(t, e, n, r)
+        },
+        undelegate: function(e, t, n) {
+            return 1 === arguments.length ? this.off(e, "**") : this.off(t, e || "**", n)
+        },
+        trigger: function(e, t) {
+            return this.each(function() {
+                st.event.trigger(e, t, this)
+            })
+        },
+        triggerHandler: function(e, n) {
+            var r = this[0];
+            return r ? st.event.trigger(e, n, r, !0) : t
+        },
+        hover: function(e, t) {
+            return this.mouseenter(e).mouseleave(t || e)
+        }
+    }), st.each("blur focus focusin focusout load resize scroll unload click dblclick mousedown mouseup mousemove mouseover mouseout mouseenter mouseleave change select submit keydown keypress keyup error contextmenu".split(" "), function(e, t) {
+        st.fn[t] = function(e, n) {
+            return arguments.length > 0 ? this.on(t, null, e, n) : this.trigger(t)
+        }, _t.test(t) && (st.event.fixHooks[t] = st.event.keyHooks), Ft.test(t) && (st.event.fixHooks[t] = st.event.mouseHooks)
+    }),
+        function(e, t) {
+            function n(e) {
+                return ht.test(e + "")
+            }
+
+            function r() {
+                var e, t = [];
+                return e = function(n, r) {
+                    return t.push(n += " ") > C.cacheLength && delete e[t.shift()], e[n] = r
+                }
+            }
+
+            function i(e) {
+                return e[P] = !0, e
+            }
+
+            function o(e) {
+                var t = L.createElement("div");
+                try {
+                    return e(t)
+                } catch (n) {
+                    return !1
+                } finally {
+                    t = null
+                }
+            }
+
+            function a(e, t, n, r) {
+                var i, o, a, s, u, l, c, d, h, g;
+                if ((t ? t.ownerDocument || t : R) !== L && D(t), t = t || L, n = n || [], !e || "string" != typeof e) return n;
+                if (1 !== (s = t.nodeType) && 9 !== s) return [];
+                if (!M && !r) {
+                    if (i = gt.exec(e))
+                        if (a = i[1]) {
+                            if (9 === s) {
+                                if (o = t.getElementById(a), !o || !o.parentNode) return n;
+                                if (o.id === a) return n.push(o), n
+                            } else if (t.ownerDocument && (o = t.ownerDocument.getElementById(a)) && O(t, o) && o.id === a) return n.push(o), n
+                        } else {
+                            if (i[2]) return Q.apply(n, K.call(t.getElementsByTagName(e), 0)), n;
+                            if ((a = i[3]) && W.getByClassName && t.getElementsByClassName) return Q.apply(n, K.call(t.getElementsByClassName(a), 0)), n
+                        }
+                    if (W.qsa && !q.test(e)) {
+                        if (c = !0, d = P, h = t, g = 9 === s && e, 1 === s && "object" !== t.nodeName.toLowerCase()) {
+                            for (l = f(e), (c = t.getAttribute("id")) ? d = c.replace(vt, "\\$&") : t.setAttribute("id", d), d = "[id='" + d + "'] ", u = l.length; u--;) l[u] = d + p(l[u]);
+                            h = dt.test(e) && t.parentNode || t, g = l.join(",")
+                        }
+                        if (g) try {
+                            return Q.apply(n, K.call(h.querySelectorAll(g), 0)), n
+                        } catch (m) {} finally {
+                            c || t.removeAttribute("id")
+                        }
+                    }
+                }
+                return x(e.replace(at, "$1"), t, n, r)
+            }
+
+            function s(e, t) {
+                for (var n = e && t && e.nextSibling; n; n = n.nextSibling)
+                    if (n === t) return -1;
+                return e ? 1 : -1
+            }
+
+            function u(e) {
+                return function(t) {
+                    var n = t.nodeName.toLowerCase();
+                    return "input" === n && t.type === e
+                }
+            }
+
+            function l(e) {
+                return function(t) {
+                    var n = t.nodeName.toLowerCase();
+                    return ("input" === n || "button" === n) && t.type === e
+                }
+            }
+
+            function c(e) {
+                return i(function(t) {
+                    return t = +t, i(function(n, r) {
+                        for (var i, o = e([], n.length, t), a = o.length; a--;) n[i = o[a]] && (n[i] = !(r[i] = n[i]))
+                    })
+                })
+            }
+
+            function f(e, t) {
+                var n, r, i, o, s, u, l, c = X[e + " "];
+                if (c) return t ? 0 : c.slice(0);
+                for (s = e, u = [], l = C.preFilter; s;) {
+                    (!n || (r = ut.exec(s))) && (r && (s = s.slice(r[0].length) || s), u.push(i = [])), n = !1, (r = lt.exec(s)) && (n = r.shift(), i.push({
+                        value: n,
+                        type: r[0].replace(at, " ")
+                    }), s = s.slice(n.length));
+                    for (o in C.filter) !(r = pt[o].exec(s)) || l[o] && !(r = l[o](r)) || (n = r.shift(), i.push({
+                        value: n,
+                        type: o,
+                        matches: r
+                    }), s = s.slice(n.length));
+                    if (!n) break
+                }
+                return t ? s.length : s ? a.error(e) : X(e, u).slice(0)
+            }
+
+            function p(e) {
+                for (var t = 0, n = e.length, r = ""; n > t; t++) r += e[t].value;
+                return r
+            }
+
+            function d(e, t, n) {
+                var r = t.dir,
+                    i = n && "parentNode" === t.dir,
+                    o = I++;
+                return t.first ? function(t, n, o) {
+                        for (; t = t[r];)
+                            if (1 === t.nodeType || i) return e(t, n, o)
+                    } : function(t, n, a) {
+                        var s, u, l, c = $ + " " + o;
+                        if (a) {
+                            for (; t = t[r];)
+                                if ((1 === t.nodeType || i) && e(t, n, a)) return !0
+                        } else
+                            for (; t = t[r];)
+                                if (1 === t.nodeType || i)
+                                    if (l = t[P] || (t[P] = {}), (u = l[r]) && u[0] === c) {
+                                        if ((s = u[1]) === !0 || s === N) return s === !0
+                                    } else if (u = l[r] = [c], u[1] = e(t, n, a) || N, u[1] === !0) return !0
+                    }
+            }
+
+            function h(e) {
+                return e.length > 1 ? function(t, n, r) {
+                        for (var i = e.length; i--;)
+                            if (!e[i](t, n, r)) return !1;
+                        return !0
+                    } : e[0]
+            }
+
+            function g(e, t, n, r, i) {
+                for (var o, a = [], s = 0, u = e.length, l = null != t; u > s; s++)(o = e[s]) && (!n || n(o, r, i)) && (a.push(o), l && t.push(s));
+                return a
+            }
+
+            function m(e, t, n, r, o, a) {
+                return r && !r[P] && (r = m(r)), o && !o[P] && (o = m(o, a)), i(function(i, a, s, u) {
+                    var l, c, f, p = [],
+                        d = [],
+                        h = a.length,
+                        m = i || b(t || "*", s.nodeType ? [s] : s, []),
+                        y = !e || !i && t ? m : g(m, p, e, s, u),
+                        v = n ? o || (i ? e : h || r) ? [] : a : y;
+                    if (n && n(y, v, s, u), r)
+                        for (l = g(v, d), r(l, [], s, u), c = l.length; c--;)(f = l[c]) && (v[d[c]] = !(y[d[c]] = f));
+                    if (i) {
+                        if (o || e) {
+                            if (o) {
+                                for (l = [], c = v.length; c--;)(f = v[c]) && l.push(y[c] = f);
+                                o(null, v = [], l, u)
+                            }
+                            for (c = v.length; c--;)(f = v[c]) && (l = o ? Z.call(i, f) : p[c]) > -1 && (i[l] = !(a[l] = f))
+                        }
+                    } else v = g(v === a ? v.splice(h, v.length) : v), o ? o(null, a, v, u) : Q.apply(a, v)
+                })
+            }
+
+            function y(e) {
+                for (var t, n, r, i = e.length, o = C.relative[e[0].type], a = o || C.relative[" "], s = o ? 1 : 0, u = d(function(e) {
+                    return e === t
+                }, a, !0), l = d(function(e) {
+                    return Z.call(t, e) > -1
+                }, a, !0), c = [function(e, n, r) {
+                    return !o && (r || n !== j) || ((t = n).nodeType ? u(e, n, r) : l(e, n, r))
+                }]; i > s; s++)
+                    if (n = C.relative[e[s].type]) c = [d(h(c), n)];
+                    else {
+                        if (n = C.filter[e[s].type].apply(null, e[s].matches), n[P]) {
+                            for (r = ++s; i > r && !C.relative[e[r].type]; r++);
+                            return m(s > 1 && h(c), s > 1 && p(e.slice(0, s - 1)).replace(at, "$1"), n, r > s && y(e.slice(s, r)), i > r && y(e = e.slice(r)), i > r && p(e))
+                        }
+                        c.push(n)
+                    }
+                return h(c)
+            }
+
+            function v(e, t) {
+                var n = 0,
+                    r = t.length > 0,
+                    o = e.length > 0,
+                    s = function(i, s, u, l, c) {
+                        var f, p, d, h = [],
+                            m = 0,
+                            y = "0",
+                            v = i && [],
+                            b = null != c,
+                            x = j,
+                            T = i || o && C.find.TAG("*", c && s.parentNode || s),
+                            w = $ += null == x ? 1 : Math.E;
+                        for (b && (j = s !== L && s, N = n); null != (f = T[y]); y++) {
+                            if (o && f) {
+                                for (p = 0; d = e[p]; p++)
+                                    if (d(f, s, u)) {
+                                        l.push(f);
+                                        break
+                                    }
+                                b && ($ = w, N = ++n)
+                            }
+                            r && ((f = !d && f) && m--, i && v.push(f))
+                        }
+                        if (m += y, r && y !== m) {
+                            for (p = 0; d = t[p]; p++) d(v, h, s, u);
+                            if (i) {
+                                if (m > 0)
+                                    for (; y--;) v[y] || h[y] || (h[y] = G.call(l));
+                                h = g(h)
+                            }
+                            Q.apply(l, h), b && !i && h.length > 0 && m + t.length > 1 && a.uniqueSort(l)
+                        }
+                        return b && ($ = w, j = x), v
+                    };
+                return r ? i(s) : s
+            }
+
+            function b(e, t, n) {
+                for (var r = 0, i = t.length; i > r; r++) a(e, t[r], n);
+                return n
+            }
+
+            function x(e, t, n, r) {
+                var i, o, a, s, u, l = f(e);
+                if (!r && 1 === l.length) {
+                    if (o = l[0] = l[0].slice(0), o.length > 2 && "ID" === (a = o[0]).type && 9 === t.nodeType && !M && C.relative[o[1].type]) {
+                        if (t = C.find.ID(a.matches[0].replace(xt, Tt), t)[0], !t) return n;
+                        e = e.slice(o.shift().value.length)
+                    }
+                    for (i = pt.needsContext.test(e) ? -1 : o.length - 1; i >= 0 && (a = o[i], !C.relative[s = a.type]); i--)
+                        if ((u = C.find[s]) && (r = u(a.matches[0].replace(xt, Tt), dt.test(o[0].type) && t.parentNode || t))) {
+                            if (o.splice(i, 1), e = r.length && p(o), !e) return Q.apply(n, K.call(r, 0)), n;
+                            break
+                        }
+                }
+                return S(e, l)(r, t, M, n, dt.test(e)), n
+            }
+
+            function T() {}
+            var w, N, C, k, E, S, A, j, D, L, H, M, q, _, F, O, B, P = "sizzle" + -new Date,
+                R = e.document,
+                W = {},
+                $ = 0,
+                I = 0,
+                z = r(),
+                X = r(),
+                U = r(),
+                V = typeof t,
+                Y = 1 << 31,
+                J = [],
+                G = J.pop,
+                Q = J.push,
+                K = J.slice,
+                Z = J.indexOf || function(e) {
+                        for (var t = 0, n = this.length; n > t; t++)
+                            if (this[t] === e) return t;
+                        return -1
+                    },
+                et = "[\\x20\\t\\r\\n\\f]",
+                tt = "(?:\\\\.|[\\w-]|[^\\x00-\\xa0])+",
+                nt = tt.replace("w", "w#"),
+                rt = "([*^$|!~]?=)",
+                it = "\\[" + et + "*(" + tt + ")" + et + "*(?:" + rt + et + "*(?:(['\"])((?:\\\\.|[^\\\\])*?)\\3|(" + nt + ")|)|)" + et + "*\\]",
+                ot = ":(" + tt + ")(?:\\(((['\"])((?:\\\\.|[^\\\\])*?)\\3|((?:\\\\.|[^\\\\()[\\]]|" + it.replace(3, 8) + ")*)|.*)\\)|)",
+                at = RegExp("^" + et + "+|((?:^|[^\\\\])(?:\\\\.)*)" + et + "+$", "g"),
+                ut = RegExp("^" + et + "*," + et + "*"),
+                lt = RegExp("^" + et + "*([\\x20\\t\\r\\n\\f>+~])" + et + "*"),
+                ct = RegExp(ot),
+                ft = RegExp("^" + nt + "$"),
+                pt = {
+                    ID: RegExp("^#(" + tt + ")"),
+                    CLASS: RegExp("^\\.(" + tt + ")"),
+                    NAME: RegExp("^\\[name=['\"]?(" + tt + ")['\"]?\\]"),
+                    TAG: RegExp("^(" + tt.replace("w", "w*") + ")"),
+                    ATTR: RegExp("^" + it),
+                    PSEUDO: RegExp("^" + ot),
+                    CHILD: RegExp("^:(only|first|last|nth|nth-last)-(child|of-type)(?:\\(" + et + "*(even|odd|(([+-]|)(\\d*)n|)" + et + "*(?:([+-]|)" + et + "*(\\d+)|))" + et + "*\\)|)", "i"),
+                    needsContext: RegExp("^" + et + "*[>+~]|:(even|odd|eq|gt|lt|nth|first|last)(?:\\(" + et + "*((?:-\\d)?\\d*)" + et + "*\\)|)(?=[^-]|$)", "i")
+                },
+                dt = /[\x20\t\r\n\f]*[+~]/,
+                ht = /\{\s*\[native code\]\s*\}/,
+                gt = /^(?:#([\w-]+)|(\w+)|\.([\w-]+))$/,
+                mt = /^(?:input|select|textarea|button)$/i,
+                yt = /^h\d$/i,
+                vt = /'|\\/g,
+                bt = /\=[\x20\t\r\n\f]*([^'"\]]*)[\x20\t\r\n\f]*\]/g,
+                xt = /\\([\da-fA-F]{1,6}[\x20\t\r\n\f]?|.)/g,
+                Tt = function(e, t) {
+                    var n = "0x" + t - 65536;
+                    return n !== n ? t : 0 > n ? String.fromCharCode(n + 65536) : String.fromCharCode(55296 | n >> 10, 56320 | 1023 & n)
+                };
+            try {
+                K.call(H.childNodes, 0)[0].nodeType
+            } catch (wt) {
+                K = function(e) {
+                    for (var t, n = []; t = this[e]; e++) n.push(t);
+                    return n
+                }
+            }
+            E = a.isXML = function(e) {
+                var t = e && (e.ownerDocument || e).documentElement;
+                return t ? "HTML" !== t.nodeName : !1
+            }, D = a.setDocument = function(e) {
+                var r = e ? e.ownerDocument || e : R;
+                return r !== L && 9 === r.nodeType && r.documentElement ? (L = r, H = r.documentElement, M = E(r), W.tagNameNoComments = o(function(e) {
+                        return e.appendChild(r.createComment("")), !e.getElementsByTagName("*").length
+                    }), W.attributes = o(function(e) {
+                        e.innerHTML = "<select></select>";
+                        var t = typeof e.lastChild.getAttribute("multiple");
+                        return "boolean" !== t && "string" !== t
+                    }), W.getByClassName = o(function(e) {
+                        return e.innerHTML = "<div class='hidden e'></div><div class='hidden'></div>", e.getElementsByClassName && e.getElementsByClassName("e").length ? (e.lastChild.className = "e", 2 === e.getElementsByClassName("e").length) : !1
+                    }), W.getByName = o(function(e) {
+                        e.id = P + 0, e.innerHTML = "<a name='" + P + "'></a><div name='" + P + "'></div>", H.insertBefore(e, H.firstChild);
+                        var t = r.getElementsByName && r.getElementsByName(P).length === 2 + r.getElementsByName(P + 0).length;
+                        return W.getIdNotName = !r.getElementById(P), H.removeChild(e), t
+                    }), C.attrHandle = o(function(e) {
+                        return e.innerHTML = "<a href='#'></a>", e.firstChild && typeof e.firstChild.getAttribute !== V && "#" === e.firstChild.getAttribute("href")
+                    }) ? {} : {
+                            href: function(e) {
+                                return e.getAttribute("href", 2)
+                            },
+                            type: function(e) {
+                                return e.getAttribute("type")
+                            }
+                        }, W.getIdNotName ? (C.find.ID = function(e, t) {
+                            if (typeof t.getElementById !== V && !M) {
+                                var n = t.getElementById(e);
+                                return n && n.parentNode ? [n] : []
+                            }
+                        }, C.filter.ID = function(e) {
+                            var t = e.replace(xt, Tt);
+                            return function(e) {
+                                return e.getAttribute("id") === t
+                            }
+                        }) : (C.find.ID = function(e, n) {
+                            if (typeof n.getElementById !== V && !M) {
+                                var r = n.getElementById(e);
+                                return r ? r.id === e || typeof r.getAttributeNode !== V && r.getAttributeNode("id").value === e ? [r] : t : []
+                            }
+                        }, C.filter.ID = function(e) {
+                            var t = e.replace(xt, Tt);
+                            return function(e) {
+                                var n = typeof e.getAttributeNode !== V && e.getAttributeNode("id");
+                                return n && n.value === t
+                            }
+                        }), C.find.TAG = W.tagNameNoComments ? function(e, n) {
+                            return typeof n.getElementsByTagName !== V ? n.getElementsByTagName(e) : t
+                        } : function(e, t) {
+                            var n, r = [],
+                                i = 0,
+                                o = t.getElementsByTagName(e);
+                            if ("*" === e) {
+                                for (; n = o[i]; i++) 1 === n.nodeType && r.push(n);
+                                return r
+                            }
+                            return o
+                        }, C.find.NAME = W.getByName && function(e, n) {
+                            return typeof n.getElementsByName !== V ? n.getElementsByName(name) : t
+                        }, C.find.CLASS = W.getByClassName && function(e, n) {
+                            return typeof n.getElementsByClassName === V || M ? t : n.getElementsByClassName(e)
+                        }, _ = [], q = [":focus"], (W.qsa = n(r.querySelectorAll)) && (o(function(e) {
+                        e.innerHTML = "<select><option selected=''></option></select>", e.querySelectorAll("[selected]").length || q.push("\\[" + et + "*(?:checked|disabled|ismap|multiple|readonly|selected|value)"), e.querySelectorAll(":checked").length || q.push(":checked")
+                    }), o(function(e) {
+                        e.innerHTML = "<input type='hidden' i=''/>", e.querySelectorAll("[i^='']").length && q.push("[*^$]=" + et + "*(?:\"\"|'')"), e.querySelectorAll(":enabled").length || q.push(":enabled", ":disabled"), e.querySelectorAll("*,:x"), q.push(",.*:")
+                    })), (W.matchesSelector = n(F = H.matchesSelector || H.mozMatchesSelector || H.webkitMatchesSelector || H.oMatchesSelector || H.msMatchesSelector)) && o(function(e) {
+                        W.disconnectedMatch = F.call(e, "div"), F.call(e, "[s!='']:x"), _.push("!=", ot)
+                    }), q = RegExp(q.join("|")), _ = RegExp(_.join("|")), O = n(H.contains) || H.compareDocumentPosition ? function(e, t) {
+                            var n = 9 === e.nodeType ? e.documentElement : e,
+                                r = t && t.parentNode;
+                            return e === r || !(!r || 1 !== r.nodeType || !(n.contains ? n.contains(r) : e.compareDocumentPosition && 16 & e.compareDocumentPosition(r)))
+                        } : function(e, t) {
+                            if (t)
+                                for (; t = t.parentNode;)
+                                    if (t === e) return !0;
+                            return !1
+                        }, B = H.compareDocumentPosition ? function(e, t) {
+                            var n;
+                            return e === t ? (A = !0, 0) : (n = t.compareDocumentPosition && e.compareDocumentPosition && e.compareDocumentPosition(t)) ? 1 & n || e.parentNode && 11 === e.parentNode.nodeType ? e === r || O(R, e) ? -1 : t === r || O(R, t) ? 1 : 0 : 4 & n ? -1 : 1 : e.compareDocumentPosition ? -1 : 1
+                        } : function(e, t) {
+                            var n, i = 0,
+                                o = e.parentNode,
+                                a = t.parentNode,
+                                u = [e],
+                                l = [t];
+                            if (e === t) return A = !0, 0;
+                            if (e.sourceIndex && t.sourceIndex) return (~t.sourceIndex || Y) - (O(R, e) && ~e.sourceIndex || Y);
+                            if (!o || !a) return e === r ? -1 : t === r ? 1 : o ? -1 : a ? 1 : 0;
+                            if (o === a) return s(e, t);
+                            for (n = e; n = n.parentNode;) u.unshift(n);
+                            for (n = t; n = n.parentNode;) l.unshift(n);
+                            for (; u[i] === l[i];) i++;
+                            return i ? s(u[i], l[i]) : u[i] === R ? -1 : l[i] === R ? 1 : 0
+                        }, A = !1, [0, 0].sort(B), W.detectDuplicates = A, L) : L
+            }, a.matches = function(e, t) {
+                return a(e, null, null, t)
+            }, a.matchesSelector = function(e, t) {
+                if ((e.ownerDocument || e) !== L && D(e), t = t.replace(bt, "='$1']"), !(!W.matchesSelector || M || _ && _.test(t) || q.test(t))) try {
+                    var n = F.call(e, t);
+                    if (n || W.disconnectedMatch || e.document && 11 !== e.document.nodeType) return n
+                } catch (r) {}
+                return a(t, L, null, [e]).length > 0
+            }, a.contains = function(e, t) {
+                return (e.ownerDocument || e) !== L && D(e), O(e, t)
+            }, a.attr = function(e, t) {
+                var n;
+                return (e.ownerDocument || e) !== L && D(e), M || (t = t.toLowerCase()), (n = C.attrHandle[t]) ? n(e) : M || W.attributes ? e.getAttribute(t) : ((n = e.getAttributeNode(t)) || e.getAttribute(t)) && e[t] === !0 ? t : n && n.specified ? n.value : null
+            }, a.error = function(e) {
+                throw Error("Syntax error, unrecognized expression: " + e)
+            }, a.uniqueSort = function(e) {
+                var t, n = [],
+                    r = 1,
+                    i = 0;
+                if (A = !W.detectDuplicates, e.sort(B), A) {
+                    for (; t = e[r]; r++) t === e[r - 1] && (i = n.push(r));
+                    for (; i--;) e.splice(n[i], 1)
+                }
+                return e
+            }, k = a.getText = function(e) {
+                var t, n = "",
+                    r = 0,
+                    i = e.nodeType;
+                if (i) {
+                    if (1 === i || 9 === i || 11 === i) {
+                        if ("string" == typeof e.textContent) return e.textContent;
+                        for (e = e.firstChild; e; e = e.nextSibling) n += k(e)
+                    } else if (3 === i || 4 === i) return e.nodeValue
+                } else
+                    for (; t = e[r]; r++) n += k(t);
+                return n
+            }, C = a.selectors = {
+                cacheLength: 50,
+                createPseudo: i,
+                match: pt,
+                find: {},
+                relative: {
+                    ">": {
+                        dir: "parentNode",
+                        first: !0
+                    },
+                    " ": {
+                        dir: "parentNode"
+                    },
+                    "+": {
+                        dir: "previousSibling",
+                        first: !0
+                    },
+                    "~": {
+                        dir: "previousSibling"
+                    }
+                },
+                preFilter: {
+                    ATTR: function(e) {
+                        return e[1] = e[1].replace(xt, Tt), e[3] = (e[4] || e[5] || "").replace(xt, Tt), "~=" === e[2] && (e[3] = " " + e[3] + " "), e.slice(0, 4)
+                    },
+                    CHILD: function(e) {
+                        return e[1] = e[1].toLowerCase(), "nth" === e[1].slice(0, 3) ? (e[3] || a.error(e[0]), e[4] = +(e[4] ? e[5] + (e[6] || 1) : 2 * ("even" === e[3] || "odd" === e[3])), e[5] = +(e[7] + e[8] || "odd" === e[3])) : e[3] && a.error(e[0]), e
+                    },
+                    PSEUDO: function(e) {
+                        var t, n = !e[5] && e[2];
+                        return pt.CHILD.test(e[0]) ? null : (e[4] ? e[2] = e[4] : n && ct.test(n) && (t = f(n, !0)) && (t = n.indexOf(")", n.length - t) - n.length) && (e[0] = e[0].slice(0, t), e[2] = n.slice(0, t)), e.slice(0, 3))
+                    }
+                },
+                filter: {
+                    TAG: function(e) {
+                        return "*" === e ? function() {
+                                return !0
+                            } : (e = e.replace(xt, Tt).toLowerCase(), function(t) {
+                                return t.nodeName && t.nodeName.toLowerCase() === e
+                            })
+                    },
+                    CLASS: function(e) {
+                        var t = z[e + " "];
+                        return t || (t = RegExp("(^|" + et + ")" + e + "(" + et + "|$)")) && z(e, function(e) {
+                                return t.test(e.className || typeof e.getAttribute !== V && e.getAttribute("class") || "")
+                            })
+                    },
+                    ATTR: function(e, t, n) {
+                        return function(r) {
+                            var i = a.attr(r, e);
+                            return null == i ? "!=" === t : t ? (i += "", "=" === t ? i === n : "!=" === t ? i !== n : "^=" === t ? n && 0 === i.indexOf(n) : "*=" === t ? n && i.indexOf(n) > -1 : "$=" === t ? n && i.substr(i.length - n.length) === n : "~=" === t ? (" " + i + " ").indexOf(n) > -1 : "|=" === t ? i === n || i.substr(0, n.length + 1) === n + "-" : !1) : !0
+                        }
+                    },
+                    CHILD: function(e, t, n, r, i) {
+                        var o = "nth" !== e.slice(0, 3),
+                            a = "last" !== e.slice(-4),
+                            s = "of-type" === t;
+                        return 1 === r && 0 === i ? function(e) {
+                                return !!e.parentNode
+                            } : function(t, n, u) {
+                                var l, c, f, p, d, h, g = o !== a ? "nextSibling" : "previousSibling",
+                                    m = t.parentNode,
+                                    y = s && t.nodeName.toLowerCase(),
+                                    v = !u && !s;
+                                if (m) {
+                                    if (o) {
+                                        for (; g;) {
+                                            for (f = t; f = f[g];)
+                                                if (s ? f.nodeName.toLowerCase() === y : 1 === f.nodeType) return !1;
+                                            h = g = "only" === e && !h && "nextSibling"
+                                        }
+                                        return !0
+                                    }
+                                    if (h = [a ? m.firstChild : m.lastChild], a && v) {
+                                        for (c = m[P] || (m[P] = {}), l = c[e] || [], d = l[0] === $ && l[1], p = l[0] === $ && l[2], f = d && m.childNodes[d]; f = ++d && f && f[g] || (p = d = 0) || h.pop();)
+                                            if (1 === f.nodeType && ++p && f === t) {
+                                                c[e] = [$, d, p];
+                                                break
+                                            }
+                                    } else if (v && (l = (t[P] || (t[P] = {}))[e]) && l[0] === $) p = l[1];
+                                    else
+                                        for (;
+                                            (f = ++d && f && f[g] || (p = d = 0) || h.pop()) && ((s ? f.nodeName.toLowerCase() !== y : 1 !== f.nodeType) || !++p || (v && ((f[P] || (f[P] = {}))[e] = [$, p]), f !== t)););
+                                    return p -= i, p === r || 0 === p % r && p / r >= 0
+                                }
+                            }
+                    },
+                    PSEUDO: function(e, t) {
+                        var n, r = C.pseudos[e] || C.setFilters[e.toLowerCase()] || a.error("unsupported pseudo: " + e);
+                        return r[P] ? r(t) : r.length > 1 ? (n = [e, e, "", t], C.setFilters.hasOwnProperty(e.toLowerCase()) ? i(function(e, n) {
+                                        for (var i, o = r(e, t), a = o.length; a--;) i = Z.call(e, o[a]), e[i] = !(n[i] = o[a])
+                                    }) : function(e) {
+                                        return r(e, 0, n)
+                                    }) : r
+                    }
+                },
+                pseudos: {
+                    not: i(function(e) {
+                        var t = [],
+                            n = [],
+                            r = S(e.replace(at, "$1"));
+                        return r[P] ? i(function(e, t, n, i) {
+                                for (var o, a = r(e, null, i, []), s = e.length; s--;)(o = a[s]) && (e[s] = !(t[s] = o))
+                            }) : function(e, i, o) {
+                                return t[0] = e, r(t, null, o, n), !n.pop()
+                            }
+                    }),
+                    has: i(function(e) {
+                        return function(t) {
+                            return a(e, t).length > 0
+                        }
+                    }),
+                    contains: i(function(e) {
+                        return function(t) {
+                            return (t.textContent || t.innerText || k(t)).indexOf(e) > -1
+                        }
+                    }),
+                    lang: i(function(e) {
+                        return ft.test(e || "") || a.error("unsupported lang: " + e), e = e.replace(xt, Tt).toLowerCase(),
+                            function(t) {
+                                var n;
+                                do
+                                    if (n = M ? t.getAttribute("xml:lang") || t.getAttribute("lang") : t.lang) return n = n.toLowerCase(), n === e || 0 === n.indexOf(e + "-");
+                                while ((t = t.parentNode) && 1 === t.nodeType);
+                                return !1
+                            }
+                    }),
+                    target: function(t) {
+                        var n = e.location && e.location.hash;
+                        return n && n.slice(1) === t.id
+                    },
+                    root: function(e) {
+                        return e === H
+                    },
+                    focus: function(e) {
+                        return e === L.activeElement && (!L.hasFocus || L.hasFocus()) && !!(e.type || e.href || ~e.tabIndex)
+                    },
+                    enabled: function(e) {
+                        return e.disabled === !1
+                    },
+                    disabled: function(e) {
+                        return e.disabled === !0
+                    },
+                    checked: function(e) {
+                        var t = e.nodeName.toLowerCase();
+                        return "input" === t && !!e.checked || "option" === t && !!e.selected
+                    },
+                    selected: function(e) {
+                        return e.parentNode && e.parentNode.selectedIndex, e.selected === !0
+                    },
+                    empty: function(e) {
+                        for (e = e.firstChild; e; e = e.nextSibling)
+                            if (e.nodeName > "@" || 3 === e.nodeType || 4 === e.nodeType) return !1;
+                        return !0
+                    },
+                    parent: function(e) {
+                        return !C.pseudos.empty(e)
+                    },
+                    header: function(e) {
+                        return yt.test(e.nodeName)
+                    },
+                    input: function(e) {
+                        return mt.test(e.nodeName)
+                    },
+                    button: function(e) {
+                        var t = e.nodeName.toLowerCase();
+                        return "input" === t && "button" === e.type || "button" === t
+                    },
+                    text: function(e) {
+                        var t;
+                        return "input" === e.nodeName.toLowerCase() && "text" === e.type && (null == (t = e.getAttribute("type")) || t.toLowerCase() === e.type)
+                    },
+                    first: c(function() {
+                        return [0]
+                    }),
+                    last: c(function(e, t) {
+                        return [t - 1]
+                    }),
+                    eq: c(function(e, t, n) {
+                        return [0 > n ? n + t : n]
+                    }),
+                    even: c(function(e, t) {
+                        for (var n = 0; t > n; n += 2) e.push(n);
+                        return e
+                    }),
+                    odd: c(function(e, t) {
+                        for (var n = 1; t > n; n += 2) e.push(n);
+                        return e
+                    }),
+                    lt: c(function(e, t, n) {
+                        for (var r = 0 > n ? n + t : n; --r >= 0;) e.push(r);
+                        return e
+                    }),
+                    gt: c(function(e, t, n) {
+                        for (var r = 0 > n ? n + t : n; t > ++r;) e.push(r);
+                        return e
+                    })
+                }
+            };
+            for (w in {
+                radio: !0,
+                checkbox: !0,
+                file: !0,
+                password: !0,
+                image: !0
+            }) C.pseudos[w] = u(w);
+            for (w in {
+                submit: !0,
+                reset: !0
+            }) C.pseudos[w] = l(w);
+            S = a.compile = function(e, t) {
+                var n, r = [],
+                    i = [],
+                    o = U[e + " "];
+                if (!o) {
+                    for (t || (t = f(e)), n = t.length; n--;) o = y(t[n]), o[P] ? r.push(o) : i.push(o);
+                    o = U(e, v(i, r))
+                }
+                return o
+            }, C.pseudos.nth = C.pseudos.eq, C.filters = T.prototype = C.pseudos, C.setFilters = new T, D(), a.attr = st.attr, st.find = a, st.expr = a.selectors, st.expr[":"] = st.expr.pseudos, st.unique = a.uniqueSort, st.text = a.getText, st.isXMLDoc = a.isXML, st.contains = a.contains
+        }(e);
+    var Pt = /Until$/,
+        Rt = /^(?:parents|prev(?:Until|All))/,
+        Wt = /^.[^:#\[\.,]*$/,
+        $t = st.expr.match.needsContext,
+        It = {
+            children: !0,
+            contents: !0,
+            next: !0,
+            prev: !0
+        };
+    st.fn.extend({
+        find: function(e) {
+            var t, n, r;
+            if ("string" != typeof e) return r = this, this.pushStack(st(e).filter(function() {
+                for (t = 0; r.length > t; t++)
+                    if (st.contains(r[t], this)) return !0
+            }));
+            for (n = [], t = 0; this.length > t; t++) st.find(e, this[t], n);
+            return n = this.pushStack(st.unique(n)), n.selector = (this.selector ? this.selector + " " : "") + e, n
+        },
+        has: function(e) {
+            var t, n = st(e, this),
+                r = n.length;
+            return this.filter(function() {
+                for (t = 0; r > t; t++)
+                    if (st.contains(this, n[t])) return !0
+            })
+        },
+        not: function(e) {
+            return this.pushStack(f(this, e, !1))
+        },
+        filter: function(e) {
+            return this.pushStack(f(this, e, !0))
+        },
+        is: function(e) {
+            return !!e && ("string" == typeof e ? $t.test(e) ? st(e, this.context).index(this[0]) >= 0 : st.filter(e, this).length > 0 : this.filter(e).length > 0)
+        },
+        closest: function(e, t) {
+            for (var n, r = 0, i = this.length, o = [], a = $t.test(e) || "string" != typeof e ? st(e, t || this.context) : 0; i > r; r++)
+                for (n = this[r]; n && n.ownerDocument && n !== t && 11 !== n.nodeType;) {
+                    if (a ? a.index(n) > -1 : st.find.matchesSelector(n, e)) {
+                        o.push(n);
+                        break
+                    }
+                    n = n.parentNode
+                }
+            return this.pushStack(o.length > 1 ? st.unique(o) : o)
+        },
+        index: function(e) {
+            return e ? "string" == typeof e ? st.inArray(this[0], st(e)) : st.inArray(e.jquery ? e[0] : e, this) : this[0] && this[0].parentNode ? this.first().prevAll().length : -1
+        },
+        add: function(e, t) {
+            var n = "string" == typeof e ? st(e, t) : st.makeArray(e && e.nodeType ? [e] : e),
+                r = st.merge(this.get(), n);
+            return this.pushStack(st.unique(r))
+        },
+        addBack: function(e) {
+            return this.add(null == e ? this.prevObject : this.prevObject.filter(e))
+        }
+    }), st.fn.andSelf = st.fn.addBack, st.each({
+        parent: function(e) {
+            var t = e.parentNode;
+            return t && 11 !== t.nodeType ? t : null
+        },
+        parents: function(e) {
+            return st.dir(e, "parentNode")
+        },
+        parentsUntil: function(e, t, n) {
+            return st.dir(e, "parentNode", n)
+        },
+        next: function(e) {
+            return c(e, "nextSibling")
+        },
+        prev: function(e) {
+            return c(e, "previousSibling")
+        },
+        nextAll: function(e) {
+            return st.dir(e, "nextSibling")
+        },
+        prevAll: function(e) {
+            return st.dir(e, "previousSibling")
+        },
+        nextUntil: function(e, t, n) {
+            return st.dir(e, "nextSibling", n)
+        },
+        prevUntil: function(e, t, n) {
+            return st.dir(e, "previousSibling", n)
+        },
+        siblings: function(e) {
+            return st.sibling((e.parentNode || {}).firstChild, e)
+        },
+        children: function(e) {
+            return st.sibling(e.firstChild)
+        },
+        contents: function(e) {
+            return st.nodeName(e, "iframe") ? e.contentDocument || e.contentWindow.document : st.merge([], e.childNodes)
+        }
+    }, function(e, t) {
+        st.fn[e] = function(n, r) {
+            var i = st.map(this, t, n);
+            return Pt.test(e) || (r = n), r && "string" == typeof r && (i = st.filter(r, i)), i = this.length > 1 && !It[e] ? st.unique(i) : i, this.length > 1 && Rt.test(e) && (i = i.reverse()), this.pushStack(i)
+        }
+    }), st.extend({
+        filter: function(e, t, n) {
+            return n && (e = ":not(" + e + ")"), 1 === t.length ? st.find.matchesSelector(t[0], e) ? [t[0]] : [] : st.find.matches(e, t)
+        },
+        dir: function(e, n, r) {
+            for (var i = [], o = e[n]; o && 9 !== o.nodeType && (r === t || 1 !== o.nodeType || !st(o).is(r));) 1 === o.nodeType && i.push(o), o = o[n];
+            return i
+        },
+        sibling: function(e, t) {
+            for (var n = []; e; e = e.nextSibling) 1 === e.nodeType && e !== t && n.push(e);
+            return n
+        }
+    });
+    var zt = "abbr|article|aside|audio|bdi|canvas|data|datalist|details|figcaption|figure|footer|header|hgroup|mark|meter|nav|output|progress|section|summary|time|video",
+        Xt = / jQuery\d+="(?:null|\d+)"/g,
+        Ut = RegExp("<(?:" + zt + ")[\\s/>]", "i"),
+        Vt = /^\s+/,
+        Yt = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:]+)[^>]*)\/>/gi,
+        Jt = /<([\w:]+)/,
+        Gt = /<tbody/i,
+        Qt = /<|&#?\w+;/,
+        Kt = /<(?:script|style|link)/i,
+        Zt = /^(?:checkbox|radio)$/i,
+        en = /checked\s*(?:[^=]|=\s*.checked.)/i,
+        tn = /^$|\/(?:java|ecma)script/i,
+        nn = /^true\/(.*)/,
+        rn = /^\s*<!(?:\[CDATA\[|--)|(?:\]\]|--)>\s*$/g,
+        on = {
+            option: [1, "<select multiple='multiple'>", "</select>"],
+            legend: [1, "<fieldset>", "</fieldset>"],
+            area: [1, "<map>", "</map>"],
+            param: [1, "<object>", "</object>"],
+            thead: [1, "<table>", "</table>"],
+            tr: [2, "<table><tbody>", "</tbody></table>"],
+            col: [2, "<table><tbody></tbody><colgroup>", "</colgroup></table>"],
+            td: [3, "<table><tbody><tr>", "</tr></tbody></table>"],
+            _default: st.support.htmlSerialize ? [0, "", ""] : [1, "X<div>", "</div>"]
+        },
+        an = p(V),
+        sn = an.appendChild(V.createElement("div"));
+    on.optgroup = on.option, on.tbody = on.tfoot = on.colgroup = on.caption = on.thead, on.th = on.td, st.fn.extend({
+        text: function(e) {
+            return st.access(this, function(e) {
+                return e === t ? st.text(this) : this.empty().append((this[0] && this[0].ownerDocument || V).createTextNode(e))
+            }, null, e, arguments.length)
+        },
+        wrapAll: function(e) {
+            if (st.isFunction(e)) return this.each(function(t) {
+                st(this).wrapAll(e.call(this, t))
+            });
+            if (this[0]) {
+                var t = st(e, this[0].ownerDocument).eq(0).clone(!0);
+                this[0].parentNode && t.insertBefore(this[0]), t.map(function() {
+                    for (var e = this; e.firstChild && 1 === e.firstChild.nodeType;) e = e.firstChild;
+                    return e
+                }).append(this)
+            }
+            return this
+        },
+        wrapInner: function(e) {
+            return st.isFunction(e) ? this.each(function(t) {
+                    st(this).wrapInner(e.call(this, t))
+                }) : this.each(function() {
+                    var t = st(this),
+                        n = t.contents();
+                    n.length ? n.wrapAll(e) : t.append(e)
+                })
+        },
+        wrap: function(e) {
+            var t = st.isFunction(e);
+            return this.each(function(n) {
+                st(this).wrapAll(t ? e.call(this, n) : e)
+            })
+        },
+        unwrap: function() {
+            return this.parent().each(function() {
+                st.nodeName(this, "body") || st(this).replaceWith(this.childNodes)
+            }).end()
+        },
+        append: function() {
+            return this.domManip(arguments, !0, function(e) {
+                (1 === this.nodeType || 11 === this.nodeType || 9 === this.nodeType) && this.appendChild(e)
+            })
+        },
+        prepend: function() {
+            return this.domManip(arguments, !0, function(e) {
+                (1 === this.nodeType || 11 === this.nodeType || 9 === this.nodeType) && this.insertBefore(e, this.firstChild)
+            })
+        },
+        before: function() {
+            return this.domManip(arguments, !1, function(e) {
+                this.parentNode && this.parentNode.insertBefore(e, this)
+            })
+        },
+        after: function() {
+            return this.domManip(arguments, !1, function(e) {
+                this.parentNode && this.parentNode.insertBefore(e, this.nextSibling)
+            })
+        },
+        remove: function(e, t) {
+            for (var n, r = 0; null != (n = this[r]); r++)(!e || st.filter(e, [n]).length > 0) && (t || 1 !== n.nodeType || st.cleanData(b(n)), n.parentNode && (t && st.contains(n.ownerDocument, n) && m(b(n, "script")), n.parentNode.removeChild(n)));
+            return this
+        },
+        empty: function() {
+            for (var e, t = 0; null != (e = this[t]); t++) {
+                for (1 === e.nodeType && st.cleanData(b(e, !1)); e.firstChild;) e.removeChild(e.firstChild);
+                e.options && st.nodeName(e, "select") && (e.options.length = 0)
+            }
+            return this
+        },
+        clone: function(e, t) {
+            return e = null == e ? !1 : e, t = null == t ? e : t, this.map(function() {
+                return st.clone(this, e, t)
+            })
+        },
+        html: function(e) {
+            return st.access(this, function(e) {
+                var n = this[0] || {},
+                    r = 0,
+                    i = this.length;
+                if (e === t) return 1 === n.nodeType ? n.innerHTML.replace(Xt, "") : t;
+                if (!("string" != typeof e || Kt.test(e) || !st.support.htmlSerialize && Ut.test(e) || !st.support.leadingWhitespace && Vt.test(e) || on[(Jt.exec(e) || ["", ""])[1].toLowerCase()])) {
+                    e = e.replace(Yt, "<$1></$2>");
+                    try {
+                        for (; i > r; r++) n = this[r] || {}, 1 === n.nodeType && (st.cleanData(b(n, !1)), n.innerHTML = e);
+                        n = 0
+                    } catch (o) {}
+                }
+                n && this.empty().append(e)
+            }, null, e, arguments.length)
+        },
+        replaceWith: function(e) {
+            var t = st.isFunction(e);
+            return t || "string" == typeof e || (e = st(e).not(this).detach()), this.domManip([e], !0, function(e) {
+                var t = this.nextSibling,
+                    n = this.parentNode;
+                (n && 1 === this.nodeType || 11 === this.nodeType) && (st(this).remove(), t ? t.parentNode.insertBefore(e, t) : n.appendChild(e))
+            })
+        },
+        detach: function(e) {
+            return this.remove(e, !0)
+        },
+        domManip: function(e, n, r) {
+            e = et.apply([], e);
+            var i, o, a, s, u, l, c = 0,
+                f = this.length,
+                p = this,
+                m = f - 1,
+                y = e[0],
+                v = st.isFunction(y);
+            if (v || !(1 >= f || "string" != typeof y || st.support.checkClone) && en.test(y)) return this.each(function(i) {
+                var o = p.eq(i);
+                v && (e[0] = y.call(this, i, n ? o.html() : t)), o.domManip(e, n, r)
+            });
+            if (f && (i = st.buildFragment(e, this[0].ownerDocument, !1, this), o = i.firstChild, 1 === i.childNodes.length && (i = o), o)) {
+                for (n = n && st.nodeName(o, "tr"), a = st.map(b(i, "script"), h), s = a.length; f > c; c++) u = i, c !== m && (u = st.clone(u, !0, !0), s && st.merge(a, b(u, "script"))), r.call(n && st.nodeName(this[c], "table") ? d(this[c], "tbody") : this[c], u, c);
+                if (s)
+                    for (l = a[a.length - 1].ownerDocument, st.map(a, g), c = 0; s > c; c++) u = a[c], tn.test(u.type || "") && !st._data(u, "globalEval") && st.contains(l, u) && (u.src ? st.ajax({
+                            url: u.src,
+                            type: "GET",
+                            dataType: "script",
+                            async: !1,
+                            global: !1,
+                            "throws": !0
+                        }) : st.globalEval((u.text || u.textContent || u.innerHTML || "").replace(rn, "")));
+                i = o = null
+            }
+            return this
+        }
+    }), st.each({
+        appendTo: "append",
+        prependTo: "prepend",
+        insertBefore: "before",
+        insertAfter: "after",
+        replaceAll: "replaceWith"
+    }, function(e, t) {
+        st.fn[e] = function(e) {
+            for (var n, r = 0, i = [], o = st(e), a = o.length - 1; a >= r; r++) n = r === a ? this : this.clone(!0), st(o[r])[t](n), tt.apply(i, n.get());
+            return this.pushStack(i)
+        }
+    }), st.extend({
+        clone: function(e, t, n) {
+            var r, i, o, a, s, u = st.contains(e.ownerDocument, e);
+            if (st.support.html5Clone || st.isXMLDoc(e) || !Ut.test("<" + e.nodeName + ">") ? s = e.cloneNode(!0) : (sn.innerHTML = e.outerHTML, sn.removeChild(s = sn.firstChild)), !(st.support.noCloneEvent && st.support.noCloneChecked || 1 !== e.nodeType && 11 !== e.nodeType || st.isXMLDoc(e)))
+                for (r = b(s), i = b(e), a = 0; null != (o = i[a]); ++a) r[a] && v(o, r[a]);
+            if (t)
+                if (n)
+                    for (i = i || b(e), r = r || b(s), a = 0; null != (o = i[a]); a++) y(o, r[a]);
+                else y(e, s);
+            return r = b(s, "script"), r.length > 0 && m(r, !u && b(e, "script")), r = i = o = null, s
+        },
+        buildFragment: function(e, t, n, r) {
+            for (var i, o, a, s, u, l, c, f = e.length, d = p(t), h = [], g = 0; f > g; g++)
+                if (o = e[g], o || 0 === o)
+                    if ("object" === st.type(o)) st.merge(h, o.nodeType ? [o] : o);
+                    else if (Qt.test(o)) {
+                        for (s = s || d.appendChild(t.createElement("div")), a = (Jt.exec(o) || ["", ""])[1].toLowerCase(), u = on[a] || on._default, s.innerHTML = u[1] + o.replace(Yt, "<$1></$2>") + u[2], c = u[0]; c--;) s = s.lastChild;
+                        if (!st.support.leadingWhitespace && Vt.test(o) && h.push(t.createTextNode(Vt.exec(o)[0])), !st.support.tbody)
+                            for (o = "table" !== a || Gt.test(o) ? "<table>" !== u[1] || Gt.test(o) ? 0 : s : s.firstChild, c = o && o.childNodes.length; c--;) st.nodeName(l = o.childNodes[c], "tbody") && !l.childNodes.length && o.removeChild(l);
+                        for (st.merge(h, s.childNodes), s.textContent = ""; s.firstChild;) s.removeChild(s.firstChild);
+                        s = d.lastChild
+                    } else h.push(t.createTextNode(o));
+            for (s && d.removeChild(s), st.support.appendChecked || st.grep(b(h, "input"), x), g = 0; o = h[g++];)
+                if ((!r || -1 === st.inArray(o, r)) && (i = st.contains(o.ownerDocument, o), s = b(d.appendChild(o), "script"), i && m(s), n))
+                    for (c = 0; o = s[c++];) tn.test(o.type || "") && n.push(o);
+            return s = null, d
+        },
+        cleanData: function(e, n) {
+            for (var r, i, o, a, s = 0, u = st.expando, l = st.cache, c = st.support.deleteExpando, f = st.event.special; null != (o = e[s]); s++)
+                if ((n || st.acceptData(o)) && (i = o[u], r = i && l[i])) {
+                    if (r.events)
+                        for (a in r.events) f[a] ? st.event.remove(o, a) : st.removeEvent(o, a, r.handle);
+                    l[i] && (delete l[i], c ? delete o[u] : o.removeAttribute !== t ? o.removeAttribute(u) : o[u] = null, K.push(i))
+                }
+        }
+    });
+    var un, ln, cn, fn = /alpha\([^)]*\)/i,
+        pn = /opacity\s*=\s*([^)]*)/,
+        dn = /^(top|right|bottom|left)$/,
+        hn = /^(none|table(?!-c[ea]).+)/,
+        gn = /^margin/,
+        mn = RegExp("^(" + ut + ")(.*)$", "i"),
+        yn = RegExp("^(" + ut + ")(?!px)[a-z%]+$", "i"),
+        vn = RegExp("^([+-])=(" + ut + ")", "i"),
+        bn = {
+            BODY: "block"
+        },
+        xn = {
+            position: "absolute",
+            visibility: "hidden",
+            display: "block"
+        },
+        Tn = {
+            letterSpacing: 0,
+            fontWeight: 400
+        },
+        wn = ["Top", "Right", "Bottom", "Left"],
+        Nn = ["Webkit", "O", "Moz", "ms"];
+    st.fn.extend({
+        css: function(e, n) {
+            return st.access(this, function(e, n, r) {
+                var i, o, a = {},
+                    s = 0;
+                if (st.isArray(n)) {
+                    for (i = ln(e), o = n.length; o > s; s++) a[n[s]] = st.css(e, n[s], !1, i);
+                    return a
+                }
+                return r !== t ? st.style(e, n, r) : st.css(e, n)
+            }, e, n, arguments.length > 1)
+        },
+        show: function() {
+            return N(this, !0)
+        },
+        hide: function() {
+            return N(this)
+        },
+        toggle: function(e) {
+            var t = "boolean" == typeof e;
+            return this.each(function() {
+                (t ? e : w(this)) ? st(this).show(): st(this).hide()
+            })
+        }
+    }), st.extend({
+        cssHooks: {
+            opacity: {
+                get: function(e, t) {
+                    if (t) {
+                        var n = un(e, "opacity");
+                        return "" === n ? "1" : n
+                    }
+                }
+            }
+        },
+        cssNumber: {
+            columnCount: !0,
+            fillOpacity: !0,
+            fontWeight: !0,
+            lineHeight: !0,
+            opacity: !0,
+            orphans: !0,
+            widows: !0,
+            zIndex: !0,
+            zoom: !0
+        },
+        cssProps: {
+            "float": st.support.cssFloat ? "cssFloat" : "styleFloat"
+        },
+        style: function(e, n, r, i) {
+            if (e && 3 !== e.nodeType && 8 !== e.nodeType && e.style) {
+                var o, a, s, u = st.camelCase(n),
+                    l = e.style;
+                if (n = st.cssProps[u] || (st.cssProps[u] = T(l, u)), s = st.cssHooks[n] || st.cssHooks[u], r === t) return s && "get" in s && (o = s.get(e, !1, i)) !== t ? o : l[n];
+                if (a = typeof r, "string" === a && (o = vn.exec(r)) && (r = (o[1] + 1) * o[2] + parseFloat(st.css(e, n)), a = "number"), !(null == r || "number" === a && isNaN(r) || ("number" !== a || st.cssNumber[u] || (r += "px"), st.support.clearCloneStyle || "" !== r || 0 !== n.indexOf("background") || (l[n] = "inherit"), s && "set" in s && (r = s.set(e, r, i)) === t))) try {
+                    l[n] = r
+                } catch (c) {}
+            }
+        },
+        css: function(e, n, r, i) {
+            var o, a, s, u = st.camelCase(n);
+            return n = st.cssProps[u] || (st.cssProps[u] = T(e.style, u)), s = st.cssHooks[n] || st.cssHooks[u], s && "get" in s && (o = s.get(e, !0, r)), o === t && (o = un(e, n, i)), "normal" === o && n in Tn && (o = Tn[n]), r ? (a = parseFloat(o), r === !0 || st.isNumeric(a) ? a || 0 : o) : o
+        },
+        swap: function(e, t, n, r) {
+            var i, o, a = {};
+            for (o in t) a[o] = e.style[o], e.style[o] = t[o];
+            i = n.apply(e, r || []);
+            for (o in t) e.style[o] = a[o];
+            return i
+        }
+    }), e.getComputedStyle ? (ln = function(t) {
+            return e.getComputedStyle(t, null)
+        }, un = function(e, n, r) {
+            var i, o, a, s = r || ln(e),
+                u = s ? s.getPropertyValue(n) || s[n] : t,
+                l = e.style;
+            return s && ("" !== u || st.contains(e.ownerDocument, e) || (u = st.style(e, n)), yn.test(u) && gn.test(n) && (i = l.width, o = l.minWidth, a = l.maxWidth, l.minWidth = l.maxWidth = l.width = u, u = s.width, l.width = i, l.minWidth = o, l.maxWidth = a)), u
+        }) : V.documentElement.currentStyle && (ln = function(e) {
+            return e.currentStyle
+        }, un = function(e, n, r) {
+            var i, o, a, s = r || ln(e),
+                u = s ? s[n] : t,
+                l = e.style;
+            return null == u && l && l[n] && (u = l[n]), yn.test(u) && !dn.test(n) && (i = l.left, o = e.runtimeStyle, a = o && o.left, a && (o.left = e.currentStyle.left), l.left = "fontSize" === n ? "1em" : u, u = l.pixelLeft + "px", l.left = i, a && (o.left = a)), "" === u ? "auto" : u
+        }), st.each(["height", "width"], function(e, n) {
+        st.cssHooks[n] = {
+            get: function(e, r, i) {
+                return r ? 0 === e.offsetWidth && hn.test(st.css(e, "display")) ? st.swap(e, xn, function() {
+                            return E(e, n, i)
+                        }) : E(e, n, i) : t
+            },
+            set: function(e, t, r) {
+                var i = r && ln(e);
+                return C(e, t, r ? k(e, n, r, st.support.boxSizing && "border-box" === st.css(e, "boxSizing", !1, i), i) : 0)
+            }
+        }
+    }), st.support.opacity || (st.cssHooks.opacity = {
+        get: function(e, t) {
+            return pn.test((t && e.currentStyle ? e.currentStyle.filter : e.style.filter) || "") ? .01 * parseFloat(RegExp.$1) + "" : t ? "1" : ""
+        },
+        set: function(e, t) {
+            var n = e.style,
+                r = e.currentStyle,
+                i = st.isNumeric(t) ? "alpha(opacity=" + 100 * t + ")" : "",
+                o = r && r.filter || n.filter || "";
+            n.zoom = 1, (t >= 1 || "" === t) && "" === st.trim(o.replace(fn, "")) && n.removeAttribute && (n.removeAttribute("filter"), "" === t || r && !r.filter) || (n.filter = fn.test(o) ? o.replace(fn, i) : o + " " + i)
+        }
+    }), st(function() {
+        st.support.reliableMarginRight || (st.cssHooks.marginRight = {
+            get: function(e, n) {
+                return n ? st.swap(e, {
+                        display: "inline-block"
+                    }, un, [e, "marginRight"]) : t
+            }
+        }), !st.support.pixelPosition && st.fn.position && st.each(["top", "left"], function(e, n) {
+            st.cssHooks[n] = {
+                get: function(e, r) {
+                    return r ? (r = un(e, n), yn.test(r) ? st(e).position()[n] + "px" : r) : t
+                }
+            }
+        })
+    }), st.expr && st.expr.filters && (st.expr.filters.hidden = function(e) {
+        return 0 === e.offsetWidth && 0 === e.offsetHeight || !st.support.reliableHiddenOffsets && "none" === (e.style && e.style.display || st.css(e, "display"))
+    }, st.expr.filters.visible = function(e) {
+        return !st.expr.filters.hidden(e)
+    }), st.each({
+        margin: "",
+        padding: "",
+        border: "Width"
+    }, function(e, t) {
+        st.cssHooks[e + t] = {
+            expand: function(n) {
+                for (var r = 0, i = {}, o = "string" == typeof n ? n.split(" ") : [n]; 4 > r; r++) i[e + wn[r] + t] = o[r] || o[r - 2] || o[0];
+                return i
+            }
+        }, gn.test(e) || (st.cssHooks[e + t].set = C)
+    });
+    var Cn = /%20/g,
+        kn = /\[\]$/,
+        En = /\r?\n/g,
+        Sn = /^(?:submit|button|image|reset)$/i,
+        An = /^(?:input|select|textarea|keygen)/i;
+    st.fn.extend({
+        serialize: function() {
+            return st.param(this.serializeArray())
+        },
+        serializeArray: function() {
+            return this.map(function() {
+                var e = st.prop(this, "elements");
+                return e ? st.makeArray(e) : this
+            }).filter(function() {
+                var e = this.type;
+                return this.name && !st(this).is(":disabled") && An.test(this.nodeName) && !Sn.test(e) && (this.checked || !Zt.test(e))
+            }).map(function(e, t) {
+                var n = st(this).val();
+                return null == n ? null : st.isArray(n) ? st.map(n, function(e) {
+                            return {
+                                name: t.name,
+                                value: e.replace(En, "\r\n")
+                            }
+                        }) : {
+                            name: t.name,
+                            value: n.replace(En, "\r\n")
+                        }
+            }).get()
+        }
+    }), st.param = function(e, n) {
+        var r, i = [],
+            o = function(e, t) {
+                t = st.isFunction(t) ? t() : null == t ? "" : t, i[i.length] = encodeURIComponent(e) + "=" + encodeURIComponent(t)
+            };
+        if (n === t && (n = st.ajaxSettings && st.ajaxSettings.traditional), st.isArray(e) || e.jquery && !st.isPlainObject(e)) st.each(e, function() {
+            o(this.name, this.value)
+        });
+        else
+            for (r in e) j(r, e[r], n, o);
+        return i.join("&").replace(Cn, "+")
+    };
+    var jn, Dn, Ln = st.now(),
+        Hn = /\?/,
+        Mn = /#.*$/,
+        qn = /([?&])_=[^&]*/,
+        _n = /^(.*?):[ \t]*([^\r\n]*)\r?$/gm,
+        Fn = /^(?:about|app|app-storage|.+-extension|file|res|widget):$/,
+        On = /^(?:GET|HEAD)$/,
+        Bn = /^\/\//,
+        Pn = /^([\w.+-]+:)(?:\/\/([^\/?#:]*)(?::(\d+)|)|)/,
+        Rn = st.fn.load,
+        Wn = {},
+        $n = {},
+        In = "*/".concat("*");
+    try {
+        Dn = Y.href
+    } catch (zn) {
+        Dn = V.createElement("a"), Dn.href = "", Dn = Dn.href
+    }
+    jn = Pn.exec(Dn.toLowerCase()) || [], st.fn.load = function(e, n, r) {
+        if ("string" != typeof e && Rn) return Rn.apply(this, arguments);
+        var i, o, a, s = this,
+            u = e.indexOf(" ");
+        return u >= 0 && (i = e.slice(u, e.length), e = e.slice(0, u)), st.isFunction(n) ? (r = n, n = t) : n && "object" == typeof n && (o = "POST"), s.length > 0 && st.ajax({
+            url: e,
+            type: o,
+            dataType: "html",
+            data: n
+        }).done(function(e) {
+            a = arguments, s.html(i ? st("<div>").append(st.parseHTML(e)).find(i) : e)
+        }).complete(r && function(e, t) {
+                s.each(r, a || [e.responseText, t, e])
+            }), this
+    }, st.each(["ajaxStart", "ajaxStop", "ajaxComplete", "ajaxError", "ajaxSuccess", "ajaxSend"], function(e, t) {
+        st.fn[t] = function(e) {
+            return this.on(t, e)
+        }
+    }), st.each(["get", "post"], function(e, n) {
+        st[n] = function(e, r, i, o) {
+            return st.isFunction(r) && (o = o || i, i = r, r = t), st.ajax({
+                url: e,
+                type: n,
+                dataType: o,
+                data: r,
+                success: i
+            })
+        }
+    }), st.extend({
+        active: 0,
+        lastModified: {},
+        etag: {},
+        ajaxSettings: {
+            url: Dn,
+            type: "GET",
+            isLocal: Fn.test(jn[1]),
+            global: !0,
+            processData: !0,
+            async: !0,
+            contentType: "application/x-www-form-urlencoded; charset=UTF-8",
+            accepts: {
+                "*": In,
+                text: "text/plain",
+                html: "text/html",
+                xml: "application/xml, text/xml",
+                json: "application/json, text/javascript"
+            },
+            contents: {
+                xml: /xml/,
+                html: /html/,
+                json: /json/
+            },
+            responseFields: {
+                xml: "responseXML",
+                text: "responseText"
+            },
+            converters: {
+                "* text": e.String,
+                "text html": !0,
+                "text json": st.parseJSON,
+                "text xml": st.parseXML
+            },
+            flatOptions: {
+                url: !0,
+                context: !0
+            }
+        },
+        ajaxSetup: function(e, t) {
+            return t ? H(H(e, st.ajaxSettings), t) : H(st.ajaxSettings, e)
+        },
+        ajaxPrefilter: D(Wn),
+        ajaxTransport: D($n),
+        ajax: function(e, n) {
+            function r(e, n, r, s) {
+                var l, f, v, b, T, N = n;
+                2 !== x && (x = 2, u && clearTimeout(u), i = t, a = s || "", w.readyState = e > 0 ? 4 : 0, r && (b = M(p, w, r)), e >= 200 && 300 > e || 304 === e ? (p.ifModified && (T = w.getResponseHeader("Last-Modified"), T && (st.lastModified[o] = T), T = w.getResponseHeader("etag"), T && (st.etag[o] = T)), 304 === e ? (l = !0, N = "notmodified") : (l = q(p, b), N = l.state, f = l.data, v = l.error, l = !v)) : (v = N, (e || !N) && (N = "error", 0 > e && (e = 0))), w.status = e, w.statusText = (n || N) + "", l ? g.resolveWith(d, [f, N, w]) : g.rejectWith(d, [w, N, v]), w.statusCode(y), y = t, c && h.trigger(l ? "ajaxSuccess" : "ajaxError", [w, p, l ? f : v]), m.fireWith(d, [w, N]), c && (h.trigger("ajaxComplete", [w, p]), --st.active || st.event.trigger("ajaxStop")))
+            }
+            "object" == typeof e && (n = e, e = t), n = n || {};
+            var i, o, a, s, u, l, c, f, p = st.ajaxSetup({}, n),
+                d = p.context || p,
+                h = p.context && (d.nodeType || d.jquery) ? st(d) : st.event,
+                g = st.Deferred(),
+                m = st.Callbacks("once memory"),
+                y = p.statusCode || {},
+                v = {},
+                b = {},
+                x = 0,
+                T = "canceled",
+                w = {
+                    readyState: 0,
+                    getResponseHeader: function(e) {
+                        var t;
+                        if (2 === x) {
+                            if (!s)
+                                for (s = {}; t = _n.exec(a);) s[t[1].toLowerCase()] = t[2];
+                            t = s[e.toLowerCase()]
+                        }
+                        return null == t ? null : t
+                    },
+                    getAllResponseHeaders: function() {
+                        return 2 === x ? a : null
+                    },
+                    setRequestHeader: function(e, t) {
+                        var n = e.toLowerCase();
+                        return x || (e = b[n] = b[n] || e, v[e] = t), this
+                    },
+                    overrideMimeType: function(e) {
+                        return x || (p.mimeType = e), this
+                    },
+                    statusCode: function(e) {
+                        var t;
+                        if (e)
+                            if (2 > x)
+                                for (t in e) y[t] = [y[t], e[t]];
+                            else w.always(e[w.status]);
+                        return this
+                    },
+                    abort: function(e) {
+                        var t = e || T;
+                        return i && i.abort(t), r(0, t), this
+                    }
+                };
+            if (g.promise(w).complete = m.add, w.success = w.done, w.error = w.fail, p.url = ((e || p.url || Dn) + "").replace(Mn, "").replace(Bn, jn[1] + "//"), p.type = n.method || n.type || p.method || p.type, p.dataTypes = st.trim(p.dataType || "*").toLowerCase().match(lt) || [""], null == p.crossDomain && (l = Pn.exec(p.url.toLowerCase()), p.crossDomain = !(!l || l[1] === jn[1] && l[2] === jn[2] && (l[3] || ("http:" === l[1] ? 80 : 443)) == (jn[3] || ("http:" === jn[1] ? 80 : 443)))), p.data && p.processData && "string" != typeof p.data && (p.data = st.param(p.data, p.traditional)), L(Wn, p, n, w), 2 === x) return w;
+            c = p.global, c && 0 === st.active++ && st.event.trigger("ajaxStart"), p.type = p.type.toUpperCase(), p.hasContent = !On.test(p.type), o = p.url, p.hasContent || (p.data && (o = p.url += (Hn.test(o) ? "&" : "?") + p.data, delete p.data), p.cache === !1 && (p.url = qn.test(o) ? o.replace(qn, "$1_=" + Ln++) : o + (Hn.test(o) ? "&" : "?") + "_=" + Ln++)), p.ifModified && (st.lastModified[o] && w.setRequestHeader("If-Modified-Since", st.lastModified[o]), st.etag[o] && w.setRequestHeader("If-None-Match", st.etag[o])), (p.data && p.hasContent && p.contentType !== !1 || n.contentType) && w.setRequestHeader("Content-Type", p.contentType), w.setRequestHeader("Accept", p.dataTypes[0] && p.accepts[p.dataTypes[0]] ? p.accepts[p.dataTypes[0]] + ("*" !== p.dataTypes[0] ? ", " + In + "; q=0.01" : "") : p.accepts["*"]);
+            for (f in p.headers) w.setRequestHeader(f, p.headers[f]);
+            if (p.beforeSend && (p.beforeSend.call(d, w, p) === !1 || 2 === x)) return w.abort();
+            T = "abort";
+            for (f in {
+                success: 1,
+                error: 1,
+                complete: 1
+            }) w[f](p[f]);
+            if (i = L($n, p, n, w)) {
+                w.readyState = 1, c && h.trigger("ajaxSend", [w, p]), p.async && p.timeout > 0 && (u = setTimeout(function() {
+                    w.abort("timeout")
+                }, p.timeout));
+                try {
+                    x = 1, i.send(v, r)
+                } catch (N) {
+                    if (!(2 > x)) throw N;
+                    r(-1, N)
+                }
+            } else r(-1, "No Transport");
+            return w
+        },
+        getScript: function(e, n) {
+            return st.get(e, t, n, "script")
+        },
+        getJSON: function(e, t, n) {
+            return st.get(e, t, n, "json")
+        }
+    }), st.ajaxSetup({
+        accepts: {
+            script: "text/javascript, application/javascript, application/ecmascript, application/x-ecmascript"
+        },
+        contents: {
+            script: /(?:java|ecma)script/
+        },
+        converters: {
+            "text script": function(e) {
+                return st.globalEval(e), e
+            }
+        }
+    }), st.ajaxPrefilter("script", function(e) {
+        e.cache === t && (e.cache = !1), e.crossDomain && (e.type = "GET", e.global = !1)
+    }), st.ajaxTransport("script", function(e) {
+        if (e.crossDomain) {
+            var n, r = V.head || st("head")[0] || V.documentElement;
+            return {
+                send: function(t, i) {
+                    n = V.createElement("script"), n.async = !0, e.scriptCharset && (n.charset = e.scriptCharset), n.src = e.url, n.onload = n.onreadystatechange = function(e, t) {
+                        (t || !n.readyState || /loaded|complete/.test(n.readyState)) && (n.onload = n.onreadystatechange = null, n.parentNode && n.parentNode.removeChild(n), n = null, t || i(200, "success"))
+                    }, r.insertBefore(n, r.firstChild)
+                },
+                abort: function() {
+                    n && n.onload(t, !0)
+                }
+            }
+        }
+    });
+    var Xn = [],
+        Un = /(=)\?(?=&|$)|\?\?/;
+    st.ajaxSetup({
+        jsonp: "callback",
+        jsonpCallback: function() {
+            var e = Xn.pop() || st.expando + "_" + Ln++;
+            return this[e] = !0, e
+        }
+    }), st.ajaxPrefilter("json jsonp", function(n, r, i) {
+        var o, a, s, u = n.jsonp !== !1 && (Un.test(n.url) ? "url" : "string" == typeof n.data && !(n.contentType || "").indexOf("application/x-www-form-urlencoded") && Un.test(n.data) && "data");
+        return u || "jsonp" === n.dataTypes[0] ? (o = n.jsonpCallback = st.isFunction(n.jsonpCallback) ? n.jsonpCallback() : n.jsonpCallback, u ? n[u] = n[u].replace(Un, "$1" + o) : n.jsonp !== !1 && (n.url += (Hn.test(n.url) ? "&" : "?") + n.jsonp + "=" + o), n.converters["script json"] = function() {
+                return s || st.error(o + " was not called"), s[0]
+            }, n.dataTypes[0] = "json", a = e[o], e[o] = function() {
+                s = arguments
+            }, i.always(function() {
+                e[o] = a, n[o] && (n.jsonpCallback = r.jsonpCallback, Xn.push(o)), s && st.isFunction(a) && a(s[0]), s = a = t
+            }), "script") : t
+    });
+    var Vn, Yn, Jn = 0,
+        Gn = e.ActiveXObject && function() {
+                var e;
+                for (e in Vn) Vn[e](t, !0)
+            };
+    st.ajaxSettings.xhr = e.ActiveXObject ? function() {
+            return !this.isLocal && _() || F()
+        } : _, Yn = st.ajaxSettings.xhr(), st.support.cors = !!Yn && "withCredentials" in Yn, Yn = st.support.ajax = !!Yn, Yn && st.ajaxTransport(function(n) {
+        if (!n.crossDomain || st.support.cors) {
+            var r;
+            return {
+                send: function(i, o) {
+                    var a, s, u = n.xhr();
+                    if (n.username ? u.open(n.type, n.url, n.async, n.username, n.password) : u.open(n.type, n.url, n.async), n.xhrFields)
+                        for (s in n.xhrFields) u[s] = n.xhrFields[s];
+                    n.mimeType && u.overrideMimeType && u.overrideMimeType(n.mimeType), n.crossDomain || i["X-Requested-With"] || (i["X-Requested-With"] = "XMLHttpRequest");
+                    try {
+                        for (s in i) u.setRequestHeader(s, i[s])
+                    } catch (l) {}
+                    u.send(n.hasContent && n.data || null), r = function(e, i) {
+                        var s, l, c, f, p;
+                        try {
+                            if (r && (i || 4 === u.readyState))
+                                if (r = t, a && (u.onreadystatechange = st.noop, Gn && delete Vn[a]), i) 4 !== u.readyState && u.abort();
+                                else {
+                                    f = {}, s = u.status, p = u.responseXML, c = u.getAllResponseHeaders(), p && p.documentElement && (f.xml = p), "string" == typeof u.responseText && (f.text = u.responseText);
+                                    try {
+                                        l = u.statusText
+                                    } catch (d) {
+                                        l = ""
+                                    }
+                                    s || !n.isLocal || n.crossDomain ? 1223 === s && (s = 204) : s = f.text ? 200 : 404
+                                }
+                        } catch (h) {
+                            i || o(-1, h)
+                        }
+                        f && o(s, l, f, c)
+                    }, n.async ? 4 === u.readyState ? setTimeout(r) : (a = ++Jn, Gn && (Vn || (Vn = {}, st(e).unload(Gn)), Vn[a] = r), u.onreadystatechange = r) : r()
+                },
+                abort: function() {
+                    r && r(t, !0)
+                }
+            }
+        }
+    });
+    var Qn, Kn, Zn = /^(?:toggle|show|hide)$/,
+        er = RegExp("^(?:([+-])=|)(" + ut + ")([a-z%]*)$", "i"),
+        tr = /queueHooks$/,
+        nr = [W],
+        rr = {
+            "*": [function(e, t) {
+                var n, r, i = this.createTween(e, t),
+                    o = er.exec(t),
+                    a = i.cur(),
+                    s = +a || 0,
+                    u = 1,
+                    l = 20;
+                if (o) {
+                    if (n = +o[2], r = o[3] || (st.cssNumber[e] ? "" : "px"), "px" !== r && s) {
+                        s = st.css(i.elem, e, !0) || n || 1;
+                        do u = u || ".5", s /= u, st.style(i.elem, e, s + r); while (u !== (u = i.cur() / a) && 1 !== u && --l)
+                    }
+                    i.unit = r, i.start = s, i.end = o[1] ? s + (o[1] + 1) * n : n
+                }
+                return i
+            }]
+        };
+    st.Animation = st.extend(P, {
+        tweener: function(e, t) {
+            st.isFunction(e) ? (t = e, e = ["*"]) : e = e.split(" ");
+            for (var n, r = 0, i = e.length; i > r; r++) n = e[r], rr[n] = rr[n] || [], rr[n].unshift(t)
+        },
+        prefilter: function(e, t) {
+            t ? nr.unshift(e) : nr.push(e)
+        }
+    }), st.Tween = $, $.prototype = {
+        constructor: $,
+        init: function(e, t, n, r, i, o) {
+            this.elem = e, this.prop = n, this.easing = i || "swing", this.options = t, this.start = this.now = this.cur(), this.end = r, this.unit = o || (st.cssNumber[n] ? "" : "px")
+        },
+        cur: function() {
+            var e = $.propHooks[this.prop];
+            return e && e.get ? e.get(this) : $.propHooks._default.get(this)
+        },
+        run: function(e) {
+            var t, n = $.propHooks[this.prop];
+            return this.pos = t = this.options.duration ? st.easing[this.easing](e, this.options.duration * e, 0, 1, this.options.duration) : e, this.now = (this.end - this.start) * t + this.start, this.options.step && this.options.step.call(this.elem, this.now, this), n && n.set ? n.set(this) : $.propHooks._default.set(this), this
+        }
+    }, $.prototype.init.prototype = $.prototype, $.propHooks = {
+        _default: {
+            get: function(e) {
+                var t;
+                return null == e.elem[e.prop] || e.elem.style && null != e.elem.style[e.prop] ? (t = st.css(e.elem, e.prop, "auto"), t && "auto" !== t ? t : 0) : e.elem[e.prop]
+            },
+            set: function(e) {
+                st.fx.step[e.prop] ? st.fx.step[e.prop](e) : e.elem.style && (null != e.elem.style[st.cssProps[e.prop]] || st.cssHooks[e.prop]) ? st.style(e.elem, e.prop, e.now + e.unit) : e.elem[e.prop] = e.now
+            }
+        }
+    }, $.propHooks.scrollTop = $.propHooks.scrollLeft = {
+        set: function(e) {
+            e.elem.nodeType && e.elem.parentNode && (e.elem[e.prop] = e.now)
+        }
+    }, st.each(["toggle", "show", "hide"], function(e, t) {
+        var n = st.fn[t];
+        st.fn[t] = function(e, r, i) {
+            return null == e || "boolean" == typeof e ? n.apply(this, arguments) : this.animate(I(t, !0), e, r, i)
+        }
+    }), st.fn.extend({
+        fadeTo: function(e, t, n, r) {
+            return this.filter(w).css("opacity", 0).show().end().animate({
+                opacity: t
+            }, e, n, r)
+        },
+        animate: function(e, t, n, r) {
+            var i = st.isEmptyObject(e),
+                o = st.speed(t, n, r),
+                a = function() {
+                    var t = P(this, st.extend({}, e), o);
+                    a.finish = function() {
+                        t.stop(!0)
+                    }, (i || st._data(this, "finish")) && t.stop(!0)
+                };
+            return a.finish = a, i || o.queue === !1 ? this.each(a) : this.queue(o.queue, a)
+        },
+        stop: function(e, n, r) {
+            var i = function(e) {
+                var t = e.stop;
+                delete e.stop, t(r)
+            };
+            return "string" != typeof e && (r = n, n = e, e = t), n && e !== !1 && this.queue(e || "fx", []), this.each(function() {
+                var t = !0,
+                    n = null != e && e + "queueHooks",
+                    o = st.timers,
+                    a = st._data(this);
+                if (n) a[n] && a[n].stop && i(a[n]);
+                else
+                    for (n in a) a[n] && a[n].stop && tr.test(n) && i(a[n]);
+                for (n = o.length; n--;) o[n].elem !== this || null != e && o[n].queue !== e || (o[n].anim.stop(r), t = !1, o.splice(n, 1));
+                (t || !r) && st.dequeue(this, e)
+            })
+        },
+        finish: function(e) {
+            return e !== !1 && (e = e || "fx"), this.each(function() {
+                var t, n = st._data(this),
+                    r = n[e + "queue"],
+                    i = n[e + "queueHooks"],
+                    o = st.timers,
+                    a = r ? r.length : 0;
+                for (n.finish = !0, st.queue(this, e, []), i && i.cur && i.cur.finish && i.cur.finish.call(this), t = o.length; t--;) o[t].elem === this && o[t].queue === e && (o[t].anim.stop(!0), o.splice(t, 1));
+                for (t = 0; a > t; t++) r[t] && r[t].finish && r[t].finish.call(this);
+                delete n.finish
+            })
+        }
+    }), st.each({
+        slideDown: I("show"),
+        slideUp: I("hide"),
+        slideToggle: I("toggle"),
+        fadeIn: {
+            opacity: "show"
+        },
+        fadeOut: {
+            opacity: "hide"
+        },
+        fadeToggle: {
+            opacity: "toggle"
+        }
+    }, function(e, t) {
+        st.fn[e] = function(e, n, r) {
+            return this.animate(t, e, n, r)
+        }
+    }), st.speed = function(e, t, n) {
+        var r = e && "object" == typeof e ? st.extend({}, e) : {
+                complete: n || !n && t || st.isFunction(e) && e,
+                duration: e,
+                easing: n && t || t && !st.isFunction(t) && t
+            };
+        return r.duration = st.fx.off ? 0 : "number" == typeof r.duration ? r.duration : r.duration in st.fx.speeds ? st.fx.speeds[r.duration] : st.fx.speeds._default, (null == r.queue || r.queue === !0) && (r.queue = "fx"), r.old = r.complete, r.complete = function() {
+            st.isFunction(r.old) && r.old.call(this), r.queue && st.dequeue(this, r.queue)
+        }, r
+    }, st.easing = {
+        linear: function(e) {
+            return e
+        },
+        swing: function(e) {
+            return .5 - Math.cos(e * Math.PI) / 2
+        }
+    }, st.timers = [], st.fx = $.prototype.init, st.fx.tick = function() {
+        var e, n = st.timers,
+            r = 0;
+        for (Qn = st.now(); n.length > r; r++) e = n[r], e() || n[r] !== e || n.splice(r--, 1);
+        n.length || st.fx.stop(), Qn = t
+    }, st.fx.timer = function(e) {
+        e() && st.timers.push(e) && st.fx.start()
+    }, st.fx.interval = 13, st.fx.start = function() {
+        Kn || (Kn = setInterval(st.fx.tick, st.fx.interval))
+    }, st.fx.stop = function() {
+        clearInterval(Kn), Kn = null
+    }, st.fx.speeds = {
+        slow: 600,
+        fast: 200,
+        _default: 400
+    }, st.fx.step = {}, st.expr && st.expr.filters && (st.expr.filters.animated = function(e) {
+        return st.grep(st.timers, function(t) {
+            return e === t.elem
+        }).length
+    }), st.fn.offset = function(e) {
+        if (arguments.length) return e === t ? this : this.each(function(t) {
+                st.offset.setOffset(this, e, t)
+            });
+        var n, r, i = {
+                top: 0,
+                left: 0
+            },
+            o = this[0],
+            a = o && o.ownerDocument;
+        if (a) return n = a.documentElement, st.contains(n, o) ? (o.getBoundingClientRect !== t && (i = o.getBoundingClientRect()), r = z(a), {
+                top: i.top + (r.pageYOffset || n.scrollTop) - (n.clientTop || 0),
+                left: i.left + (r.pageXOffset || n.scrollLeft) - (n.clientLeft || 0)
+            }) : i
+    }, st.offset = {
+        setOffset: function(e, t, n) {
+            var r = st.css(e, "position");
+            "static" === r && (e.style.position = "relative");
+            var i, o, a = st(e),
+                s = a.offset(),
+                u = st.css(e, "top"),
+                l = st.css(e, "left"),
+                c = ("absolute" === r || "fixed" === r) && st.inArray("auto", [u, l]) > -1,
+                f = {},
+                p = {};
+            c ? (p = a.position(), i = p.top, o = p.left) : (i = parseFloat(u) || 0, o = parseFloat(l) || 0), st.isFunction(t) && (t = t.call(e, n, s)), null != t.top && (f.top = t.top - s.top + i), null != t.left && (f.left = t.left - s.left + o), "using" in t ? t.using.call(e, f) : a.css(f)
+        }
+    }, st.fn.extend({
+        position: function() {
+            if (this[0]) {
+                var e, t, n = {
+                        top: 0,
+                        left: 0
+                    },
+                    r = this[0];
+                return "fixed" === st.css(r, "position") ? t = r.getBoundingClientRect() : (e = this.offsetParent(), t = this.offset(), st.nodeName(e[0], "html") || (n = e.offset()), n.top += st.css(e[0], "borderTopWidth", !0), n.left += st.css(e[0], "borderLeftWidth", !0)), {
+                    top: t.top - n.top - st.css(r, "marginTop", !0),
+                    left: t.left - n.left - st.css(r, "marginLeft", !0)
+                }
+            }
+        },
+        offsetParent: function() {
+            return this.map(function() {
+                for (var e = this.offsetParent || V.documentElement; e && !st.nodeName(e, "html") && "static" === st.css(e, "position");) e = e.offsetParent;
+                return e || V.documentElement
+            })
+        }
+    }), st.each({
+        scrollLeft: "pageXOffset",
+        scrollTop: "pageYOffset"
+    }, function(e, n) {
+        var r = /Y/.test(n);
+        st.fn[e] = function(i) {
+            return st.access(this, function(e, i, o) {
+                var a = z(e);
+                return o === t ? a ? n in a ? a[n] : a.document.documentElement[i] : e[i] : (a ? a.scrollTo(r ? st(a).scrollLeft() : o, r ? o : st(a).scrollTop()) : e[i] = o, t)
+            }, e, i, arguments.length, null)
+        }
+    }), st.each({
+        Height: "height",
+        Width: "width"
+    }, function(e, n) {
+        st.each({
+            padding: "inner" + e,
+            content: n,
+            "": "outer" + e
+        }, function(r, i) {
+            st.fn[i] = function(i, o) {
+                var a = arguments.length && (r || "boolean" != typeof i),
+                    s = r || (i === !0 || o === !0 ? "margin" : "border");
+                return st.access(this, function(n, r, i) {
+                    var o;
+                    return st.isWindow(n) ? n.document.documentElement["client" + e] : 9 === n.nodeType ? (o = n.documentElement, Math.max(n.body["scroll" + e], o["scroll" + e], n.body["offset" + e], o["offset" + e], o["client" + e])) : i === t ? st.css(n, r, s) : st.style(n, r, i, s)
+                }, n, a ? i : t, a, null)
+            }
+        })
+    }), e.jQuery = e.$ = st, "function" == typeof define && define.amd && define.amd.jQuery && define("jquery", [], function() {
+        return st
+    })
+})(window);
+
+/*!
+ * jQuery Form Plugin
+ * version: 3.51.0-2014.06.20
+ * Requires jQuery v1.5 or later
+ * Copyright (c) 2014 M. Alsup
+ * Examples and documentation at: http://malsup.com/jquery/form/
+ * Project repository: https://github.com/malsup/form
+ * Dual licensed under the MIT and GPL licenses.
+ * https://github.com/malsup/form#copyright-and-license
+ */
+! function(e) {
+    "use strict";
+    "function" == typeof define && define.amd ? define(["jquery"], e) : e("undefined" != typeof jQuery ? jQuery : window.Zepto)
+}(function(e) {
+    "use strict";
+
+    function t(t) {
+        var r = t.data;
+        t.isDefaultPrevented() || (t.preventDefault(), e(t.target).ajaxSubmit(r))
+    }
+
+    function r(t) {
+        var r = t.target,
+            a = e(r);
+        if (!a.is("[type=submit],[type=image]")) {
+            var n = a.closest("[type=submit]");
+            if (0 === n.length) return;
+            r = n[0]
+        }
+        var i = this;
+        if (i.clk = r, "image" == r.type)
+            if (void 0 !== t.offsetX) i.clk_x = t.offsetX, i.clk_y = t.offsetY;
+            else if ("function" == typeof e.fn.offset) {
+                var o = a.offset();
+                i.clk_x = t.pageX - o.left, i.clk_y = t.pageY - o.top
+            } else i.clk_x = t.pageX - r.offsetLeft, i.clk_y = t.pageY - r.offsetTop;
+        setTimeout(function() {
+            i.clk = i.clk_x = i.clk_y = null
+        }, 100)
+    }
+
+    function a() {
+        if (e.fn.ajaxSubmit.debug) {
+            var t = "[jquery.form] " + Array.prototype.join.call(arguments, "");
+            window.console && window.console.log ? window.console.log(t) : window.opera && window.opera.postError && window.opera.postError(t)
+        }
+    }
+    var n = {};
+    n.fileapi = void 0 !== e("<input type='file'/>").get(0).files, n.formdata = void 0 !== window.FormData;
+    var i = !!e.fn.prop;
+    e.fn.attr2 = function() {
+        if (!i) return this.attr.apply(this, arguments);
+        var e = this.prop.apply(this, arguments);
+        return e && e.jquery || "string" == typeof e ? e : this.attr.apply(this, arguments)
+    }, e.fn.ajaxSubmit = function(t) {
+        function r(r) {
+            var a, n, i = e.param(r, t.traditional).split("&"),
+                o = i.length,
+                s = [];
+            for (a = 0; o > a; a++) i[a] = i[a].replace(/\+/g, " "), n = i[a].split("="), s.push([decodeURIComponent(n[0]), decodeURIComponent(n[1])]);
+            return s
+        }
+
+        function o(a) {
+            for (var n = new FormData, i = 0; i < a.length; i++) n.append(a[i].name, a[i].value);
+            if (t.extraData) {
+                var o = r(t.extraData);
+                for (i = 0; i < o.length; i++) o[i] && n.append(o[i][0], o[i][1])
+            }
+            t.data = null;
+            var s = e.extend(!0, {}, e.ajaxSettings, t, {
+                contentType: !1,
+                processData: !1,
+                cache: !1,
+                type: u || "POST"
+            });
+            t.uploadProgress && (s.xhr = function() {
+                var r = e.ajaxSettings.xhr();
+                return r.upload && r.upload.addEventListener("progress", function(e) {
+                    var r = 0,
+                        a = e.loaded || e.position,
+                        n = e.total;
+                    e.lengthComputable && (r = Math.ceil(a / n * 100)), t.uploadProgress(e, a, n, r)
+                }, !1), r
+            }), s.data = null;
+            var c = s.beforeSend;
+            return s.beforeSend = function(e, r) {
+                r.data = t.formData ? t.formData : n, c && c.call(this, e, r)
+            }, e.ajax(s)
+        }
+
+        function s(r) {
+            function n(e) {
+                var t = null;
+                try {
+                    e.contentWindow && (t = e.contentWindow.document)
+                } catch (r) {
+                    a("cannot get iframe.contentWindow document: " + r)
+                }
+                if (t) return t;
+                try {
+                    t = e.contentDocument ? e.contentDocument : e.document
+                } catch (r) {
+                    a("cannot get iframe.contentDocument: " + r), t = e.document
+                }
+                return t
+            }
+
+            function o() {
+                function t() {
+                    try {
+                        var e = n(g).readyState;
+                        a("state = " + e), e && "uninitialized" == e.toLowerCase() && setTimeout(t, 50)
+                    } catch (r) {
+                        a("Server abort: ", r, " (", r.name, ")"), s(k), j && clearTimeout(j), j = void 0
+                    }
+                }
+                var r = f.attr2("target"),
+                    i = f.attr2("action"),
+                    o = "multipart/form-data",
+                    c = f.attr("enctype") || f.attr("encoding") || o;
+                w.setAttribute("target", p), (!u || /post/i.test(u)) && w.setAttribute("method", "POST"), i != m.url && w.setAttribute("action", m.url), m.skipEncodingOverride || u && !/post/i.test(u) || f.attr({
+                    encoding: "multipart/form-data",
+                    enctype: "multipart/form-data"
+                }), m.timeout && (j = setTimeout(function() {
+                    T = !0, s(D)
+                }, m.timeout));
+                var l = [];
+                try {
+                    if (m.extraData)
+                        for (var d in m.extraData) m.extraData.hasOwnProperty(d) && l.push(e.isPlainObject(m.extraData[d]) && m.extraData[d].hasOwnProperty("name") && m.extraData[d].hasOwnProperty("value") ? e('<input type="hidden" name="' + m.extraData[d].name + '">').val(m.extraData[d].value).appendTo(w)[0] : e('<input type="hidden" name="' + d + '">').val(m.extraData[d]).appendTo(w)[0]);
+                    m.iframeTarget || v.appendTo("body"), g.attachEvent ? g.attachEvent("onload", s) : g.addEventListener("load", s, !1), setTimeout(t, 15);
+                    try {
+                        w.submit()
+                    } catch (h) {
+                        var x = document.createElement("form").submit;
+                        x.apply(w)
+                    }
+                } finally {
+                    w.setAttribute("action", i), w.setAttribute("enctype", c), r ? w.setAttribute("target", r) : f.removeAttr("target"), e(l).remove()
+                }
+            }
+
+            function s(t) {
+                if (!x.aborted && !F) {
+                    if (M = n(g), M || (a("cannot access response document"), t = k), t === D && x) return x.abort("timeout"), void S.reject(x, "timeout");
+                    if (t == k && x) return x.abort("server abort"), void S.reject(x, "error", "server abort");
+                    if (M && M.location.href != m.iframeSrc || T) {
+                        g.detachEvent ? g.detachEvent("onload", s) : g.removeEventListener("load", s, !1);
+                        var r, i = "success";
+                        try {
+                            if (T) throw "timeout";
+                            var o = "xml" == m.dataType || M.XMLDocument || e.isXMLDoc(M);
+                            if (a("isXml=" + o), !o && window.opera && (null === M.body || !M.body.innerHTML) && --O) return a("requeing onLoad callback, DOM not available"), void setTimeout(s, 250);
+                            var u = M.body ? M.body : M.documentElement;
+                            x.responseText = u ? u.innerHTML : null, x.responseXML = M.XMLDocument ? M.XMLDocument : M, o && (m.dataType = "xml"), x.getResponseHeader = function(e) {
+                                var t = {
+                                    "content-type": m.dataType
+                                };
+                                return t[e.toLowerCase()]
+                            }, u && (x.status = Number(u.getAttribute("status")) || x.status, x.statusText = u.getAttribute("statusText") || x.statusText);
+                            var c = (m.dataType || "").toLowerCase(),
+                                l = /(json|script|text)/.test(c);
+                            if (l || m.textarea) {
+                                var f = M.getElementsByTagName("textarea")[0];
+                                if (f) x.responseText = f.value, x.status = Number(f.getAttribute("status")) || x.status, x.statusText = f.getAttribute("statusText") || x.statusText;
+                                else if (l) {
+                                    var p = M.getElementsByTagName("pre")[0],
+                                        h = M.getElementsByTagName("body")[0];
+                                    p ? x.responseText = p.textContent ? p.textContent : p.innerText : h && (x.responseText = h.textContent ? h.textContent : h.innerText)
+                                }
+                            } else "xml" == c && !x.responseXML && x.responseText && (x.responseXML = X(x.responseText));
+                            try {
+                                E = _(x, c, m)
+                            } catch (y) {
+                                i = "parsererror", x.error = r = y || i
+                            }
+                        } catch (y) {
+                            a("error caught: ", y), i = "error", x.error = r = y || i
+                        }
+                        x.aborted && (a("upload aborted"), i = null), x.status && (i = x.status >= 200 && x.status < 300 || 304 === x.status ? "success" : "error"), "success" === i ? (m.success && m.success.call(m.context, E, "success", x), S.resolve(x.responseText, "success", x), d && e.event.trigger("ajaxSuccess", [x, m])) : i && (void 0 === r && (r = x.statusText), m.error && m.error.call(m.context, x, i, r), S.reject(x, "error", r), d && e.event.trigger("ajaxError", [x, m, r])), d && e.event.trigger("ajaxComplete", [x, m]), d && !--e.active && e.event.trigger("ajaxStop"), m.complete && m.complete.call(m.context, x, i), F = !0, m.timeout && clearTimeout(j), setTimeout(function() {
+                            m.iframeTarget ? v.attr("src", m.iframeSrc) : v.remove(), x.responseXML = null
+                        }, 100)
+                    }
+                }
+            }
+            var c, l, m, d, p, v, g, x, y, b, T, j, w = f[0],
+                S = e.Deferred();
+            if (S.abort = function(e) {
+                    x.abort(e)
+                }, r)
+                for (l = 0; l < h.length; l++) c = e(h[l]), i ? c.prop("disabled", !1) : c.removeAttr("disabled");
+            if (m = e.extend(!0, {}, e.ajaxSettings, t), m.context = m.context || m, p = "jqFormIO" + (new Date).getTime(), m.iframeTarget ? (v = e(m.iframeTarget), b = v.attr2("name"), b ? p = b : v.attr2("name", p)) : (v = e('<iframe name="' + p + '" src="' + m.iframeSrc + '" />'), v.css({
+                        position: "absolute",
+                        top: "-1000px",
+                        left: "-1000px"
+                    })), g = v[0], x = {
+                    aborted: 0,
+                    responseText: null,
+                    responseXML: null,
+                    status: 0,
+                    statusText: "n/a",
+                    getAllResponseHeaders: function() {},
+                    getResponseHeader: function() {},
+                    setRequestHeader: function() {},
+                    abort: function(t) {
+                        var r = "timeout" === t ? "timeout" : "aborted";
+                        a("aborting upload... " + r), this.aborted = 1;
+                        try {
+                            g.contentWindow.document.execCommand && g.contentWindow.document.execCommand("Stop")
+                        } catch (n) {}
+                        v.attr("src", m.iframeSrc), x.error = r, m.error && m.error.call(m.context, x, r, t), d && e.event.trigger("ajaxError", [x, m, r]), m.complete && m.complete.call(m.context, x, r)
+                    }
+                }, d = m.global, d && 0 === e.active++ && e.event.trigger("ajaxStart"), d && e.event.trigger("ajaxSend", [x, m]), m.beforeSend && m.beforeSend.call(m.context, x, m) === !1) return m.global && e.active--, S.reject(), S;
+            if (x.aborted) return S.reject(), S;
+            y = w.clk, y && (b = y.name, b && !y.disabled && (m.extraData = m.extraData || {}, m.extraData[b] = y.value, "image" == y.type && (m.extraData[b + ".x"] = w.clk_x, m.extraData[b + ".y"] = w.clk_y)));
+            var D = 1,
+                k = 2,
+                A = e("meta[name=csrf-token]").attr("content"),
+                L = e("meta[name=csrf-param]").attr("content");
+            L && A && (m.extraData = m.extraData || {}, m.extraData[L] = A), m.forceSync ? o() : setTimeout(o, 10);
+            var E, M, F, O = 50,
+                X = e.parseXML || function(e, t) {
+                        return window.ActiveXObject ? (t = new ActiveXObject("Microsoft.XMLDOM"), t.async = "false", t.loadXML(e)) : t = (new DOMParser).parseFromString(e, "text/xml"), t && t.documentElement && "parsererror" != t.documentElement.nodeName ? t : null
+                    },
+                C = e.parseJSON || function(e) {
+                        return window.eval("(" + e + ")")
+                    },
+                _ = function(t, r, a) {
+                    var n = t.getResponseHeader("content-type") || "",
+                        i = "xml" === r || !r && n.indexOf("xml") >= 0,
+                        o = i ? t.responseXML : t.responseText;
+                    return i && "parsererror" === o.documentElement.nodeName && e.error && e.error("parsererror"), a && a.dataFilter && (o = a.dataFilter(o, r)), "string" == typeof o && ("json" === r || !r && n.indexOf("json") >= 0 ? o = C(o) : ("script" === r || !r && n.indexOf("javascript") >= 0) && e.globalEval(o)), o
+                };
+            return S
+        }
+        if (!this.length) return a("ajaxSubmit: skipping submit process - no element selected"), this;
+        var u, c, l, f = this;
+        "function" == typeof t ? t = {
+                success: t
+            } : void 0 === t && (t = {}), u = t.type || this.attr2("method"), c = t.url || this.attr2("action"), l = "string" == typeof c ? e.trim(c) : "", l = l || window.location.href || "", l && (l = (l.match(/^([^#]+)/) || [])[1]), t = e.extend(!0, {
+            url: l,
+            success: e.ajaxSettings.success,
+            type: u || e.ajaxSettings.type,
+            iframeSrc: /^https/i.test(window.location.href || "") ? "javascript:false" : "about:blank"
+        }, t);
+        var m = {};
+        if (this.trigger("form-pre-serialize", [this, t, m]), m.veto) return a("ajaxSubmit: submit vetoed via form-pre-serialize trigger"), this;
+        if (t.beforeSerialize && t.beforeSerialize(this, t) === !1) return a("ajaxSubmit: submit aborted via beforeSerialize callback"), this;
+        var d = t.traditional;
+        void 0 === d && (d = e.ajaxSettings.traditional);
+        var p, h = [],
+            v = this.formToArray(t.semantic, h);
+        if (t.data && (t.extraData = t.data, p = e.param(t.data, d)), t.beforeSubmit && t.beforeSubmit(v, this, t) === !1) return a("ajaxSubmit: submit aborted via beforeSubmit callback"), this;
+        if (this.trigger("form-submit-validate", [v, this, t, m]), m.veto) return a("ajaxSubmit: submit vetoed via form-submit-validate trigger"), this;
+        var g = e.param(v, d);
+        p && (g = g ? g + "&" + p : p), "GET" == t.type.toUpperCase() ? (t.url += (t.url.indexOf("?") >= 0 ? "&" : "?") + g, t.data = null) : t.data = g;
+        var x = [];
+        if (t.resetForm && x.push(function() {
+                f.resetForm()
+            }), t.clearForm && x.push(function() {
+                f.clearForm(t.includeHidden)
+            }), !t.dataType && t.target) {
+            var y = t.success || function() {};
+            x.push(function(r) {
+                var a = t.replaceTarget ? "replaceWith" : "html";
+                e(t.target)[a](r).each(y, arguments)
+            })
+        } else t.success && x.push(t.success);
+        if (t.success = function(e, r, a) {
+                for (var n = t.context || this, i = 0, o = x.length; o > i; i++) x[i].apply(n, [e, r, a || f, f])
+            }, t.error) {
+            var b = t.error;
+            t.error = function(e, r, a) {
+                var n = t.context || this;
+                b.apply(n, [e, r, a, f])
+            }
+        }
+        if (t.complete) {
+            var T = t.complete;
+            t.complete = function(e, r) {
+                var a = t.context || this;
+                T.apply(a, [e, r, f])
+            }
+        }
+        var j = e("input[type=file]:enabled", this).filter(function() {
+                return "" !== e(this).val()
+            }),
+            w = j.length > 0,
+            S = "multipart/form-data",
+            D = f.attr("enctype") == S || f.attr("encoding") == S,
+            k = n.fileapi && n.formdata;
+        a("fileAPI :" + k);
+        var A, L = (w || D) && !k;
+        t.iframe !== !1 && (t.iframe || L) ? t.closeKeepAlive ? e.get(t.closeKeepAlive, function() {
+                    A = s(v)
+                }) : A = s(v) : A = (w || D) && k ? o(v) : e.ajax(t), f.removeData("jqxhr").data("jqxhr", A);
+        for (var E = 0; E < h.length; E++) h[E] = null;
+        return this.trigger("form-submit-notify", [this, t]), this
+    }, e.fn.ajaxForm = function(n) {
+        if (n = n || {}, n.delegation = n.delegation && e.isFunction(e.fn.on), !n.delegation && 0 === this.length) {
+            var i = {
+                s: this.selector,
+                c: this.context
+            };
+            return !e.isReady && i.s ? (a("DOM not ready, queuing ajaxForm"), e(function() {
+                    e(i.s, i.c).ajaxForm(n)
+                }), this) : (a("terminating; zero elements found by selector" + (e.isReady ? "" : " (DOM not ready)")), this)
+        }
+        return n.delegation ? (e(document).off("submit.form-plugin", this.selector, t).off("click.form-plugin", this.selector, r).on("submit.form-plugin", this.selector, n, t).on("click.form-plugin", this.selector, n, r), this) : this.ajaxFormUnbind().bind("submit.form-plugin", n, t).bind("click.form-plugin", n, r)
+    }, e.fn.ajaxFormUnbind = function() {
+        return this.unbind("submit.form-plugin click.form-plugin")
+    }, e.fn.formToArray = function(t, r) {
+        var a = [];
+        if (0 === this.length) return a;
+        var i, o = this[0],
+            s = this.attr("id"),
+            u = t ? o.getElementsByTagName("*") : o.elements;
+        if (u && !/MSIE [678]/.test(navigator.userAgent) && (u = e(u).get()), s && (i = e(':input[form="' + s + '"]').get(), i.length && (u = (u || []).concat(i))), !u || !u.length) return a;
+        var c, l, f, m, d, p, h;
+        for (c = 0, p = u.length; p > c; c++)
+            if (d = u[c], f = d.name, f && !d.disabled)
+                if (t && o.clk && "image" == d.type) o.clk == d && (a.push({
+                    name: f,
+                    value: e(d).val(),
+                    type: d.type
+                }), a.push({
+                    name: f + ".x",
+                    value: o.clk_x
+                }, {
+                    name: f + ".y",
+                    value: o.clk_y
+                }));
+                else if (m = e.fieldValue(d, !0), m && m.constructor == Array)
+                    for (r && r.push(d), l = 0, h = m.length; h > l; l++) a.push({
+                        name: f,
+                        value: m[l]
+                    });
+                else if (n.fileapi && "file" == d.type) {
+                    r && r.push(d);
+                    var v = d.files;
+                    if (v.length)
+                        for (l = 0; l < v.length; l++) a.push({
+                            name: f,
+                            value: v[l],
+                            type: d.type
+                        });
+                    else a.push({
+                        name: f,
+                        value: "",
+                        type: d.type
+                    })
+                } else null !== m && "undefined" != typeof m && (r && r.push(d), a.push({
+                    name: f,
+                    value: m,
+                    type: d.type,
+                    required: d.required
+                }));
+        if (!t && o.clk) {
+            var g = e(o.clk),
+                x = g[0];
+            f = x.name, f && !x.disabled && "image" == x.type && (a.push({
+                name: f,
+                value: g.val()
+            }), a.push({
+                name: f + ".x",
+                value: o.clk_x
+            }, {
+                name: f + ".y",
+                value: o.clk_y
+            }))
+        }
+        return a
+    }, e.fn.formSerialize = function(t) {
+        return e.param(this.formToArray(t))
+    }, e.fn.fieldSerialize = function(t) {
+        var r = [];
+        return this.each(function() {
+            var a = this.name;
+            if (a) {
+                var n = e.fieldValue(this, t);
+                if (n && n.constructor == Array)
+                    for (var i = 0, o = n.length; o > i; i++) r.push({
+                        name: a,
+                        value: n[i]
+                    });
+                else null !== n && "undefined" != typeof n && r.push({
+                    name: this.name,
+                    value: n
+                })
+            }
+        }), e.param(r)
+    }, e.fn.fieldValue = function(t) {
+        for (var r = [], a = 0, n = this.length; n > a; a++) {
+            var i = this[a],
+                o = e.fieldValue(i, t);
+            null === o || "undefined" == typeof o || o.constructor == Array && !o.length || (o.constructor == Array ? e.merge(r, o) : r.push(o))
+        }
+        return r
+    }, e.fieldValue = function(t, r) {
+        var a = t.name,
+            n = t.type,
+            i = t.tagName.toLowerCase();
+        if (void 0 === r && (r = !0), r && (!a || t.disabled || "reset" == n || "button" == n || ("checkbox" == n || "radio" == n) && !t.checked || ("submit" == n || "image" == n) && t.form && t.form.clk != t || "select" == i && -1 == t.selectedIndex)) return null;
+        if ("select" == i) {
+            var o = t.selectedIndex;
+            if (0 > o) return null;
+            for (var s = [], u = t.options, c = "select-one" == n, l = c ? o + 1 : u.length, f = c ? o : 0; l > f; f++) {
+                var m = u[f];
+                if (m.selected) {
+                    var d = m.value;
+                    if (d || (d = m.attributes && m.attributes.value && !m.attributes.value.specified ? m.text : m.value), c) return d;
+                    s.push(d)
+                }
+            }
+            return s
+        }
+        return e(t).val()
+    }, e.fn.clearForm = function(t) {
+        return this.each(function() {
+            e("input,select,textarea", this).clearFields(t)
+        })
+    }, e.fn.clearFields = e.fn.clearInputs = function(t) {
+        var r = /^(?:color|date|datetime|email|month|number|password|range|search|tel|text|time|url|week)$/i;
+        return this.each(function() {
+            var a = this.type,
+                n = this.tagName.toLowerCase();
+            r.test(a) || "textarea" == n ? this.value = "" : "checkbox" == a || "radio" == a ? this.checked = !1 : "select" == n ? this.selectedIndex = -1 : "file" == a ? /MSIE/.test(navigator.userAgent) ? e(this).replaceWith(e(this).clone(!0)) : e(this).val("") : t && (t === !0 && /hidden/.test(a) || "string" == typeof t && e(this).is(t)) && (this.value = "")
+        })
+    }, e.fn.resetForm = function() {
+        return this.each(function() {
+            ("function" == typeof this.reset || "object" == typeof this.reset && !this.reset.nodeType) && this.reset()
+        })
+    }, e.fn.enable = function(e) {
+        return void 0 === e && (e = !0), this.each(function() {
+            this.disabled = !e
+        })
+    }, e.fn.selected = function(t) {
+        return void 0 === t && (t = !0), this.each(function() {
+            var r = this.type;
+            if ("checkbox" == r || "radio" == r) this.checked = t;
+            else if ("option" == this.tagName.toLowerCase()) {
+                var a = e(this).parent("select");
+                t && a[0] && "select-one" == a[0].type && a.find("option").selected(!1), this.selected = t
+            }
+        })
+    }, e.fn.ajaxSubmit.debug = !1
+});
+
+/*! jQuery Validation Plugin - v1.12.0 - 4/1/2014
+ * http://jqueryvalidation.org/
+ * Copyright (c) 2014 JÃƒÂ¶rn Zaefferer; Licensed MIT */
+! function(a) {
+    a.extend(a.fn, {
+        validate: function(b) {
+            if (!this.length) return void(b && b.debug && window.console && console.warn("Nothing selected, can't validate, returning nothing."));
+            var c = a.data(this[0], "validator");
+            return c ? c : (this.attr("novalidate", "novalidate"), c = new a.validator(b, this[0]), a.data(this[0], "validator", c), c.settings.onsubmit && (this.validateDelegate(":submit", "click", function(b) {
+                    c.settings.submitHandler && (c.submitButton = b.target), a(b.target).hasClass("cancel") && (c.cancelSubmit = !0), void 0 !== a(b.target).attr("formnovalidate") && (c.cancelSubmit = !0)
+                }), this.submit(function(b) {
+                    function d() {
+                        var d;
+                        return c.settings.submitHandler ? (c.submitButton && (d = a("<input type='hidden'/>").attr("name", c.submitButton.name).val(a(c.submitButton).val()).appendTo(c.currentForm)), c.settings.submitHandler.call(c, c.currentForm, b), c.submitButton && d.remove(), !1) : !0
+                    }
+                    return c.settings.debug && b.preventDefault(), c.cancelSubmit ? (c.cancelSubmit = !1, d()) : c.form() ? c.pendingRequest ? (c.formSubmitted = !0, !1) : d() : (c.focusInvalid(), !1)
+                })), c)
+        },
+        valid: function() {
+            var b, c;
+            return a(this[0]).is("form") ? b = this.validate().form() : (b = !0, c = a(this[0].form).validate(), this.each(function() {
+                    b = c.element(this) && b
+                })), b
+        },
+        removeAttrs: function(b) {
+            var c = {},
+                d = this;
+            return a.each(b.split(/\s/), function(a, b) {
+                c[b] = d.attr(b), d.removeAttr(b)
+            }), c
+        },
+        rules: function(b, c) {
+            var d, e, f, g, h, i, j = this[0];
+            if (b) switch (d = a.data(j.form, "validator").settings, e = d.rules, f = a.validator.staticRules(j), b) {
+                case "add":
+                    a.extend(f, a.validator.normalizeRule(c)), delete f.messages, e[j.name] = f, c.messages && (d.messages[j.name] = a.extend(d.messages[j.name], c.messages));
+                    break;
+                case "remove":
+                    return c ? (i = {}, a.each(c.split(/\s/), function(b, c) {
+                            i[c] = f[c], delete f[c], "required" === c && a(j).removeAttr("aria-required")
+                        }), i) : (delete e[j.name], f)
+            }
+            return g = a.validator.normalizeRules(a.extend({}, a.validator.classRules(j), a.validator.attributeRules(j), a.validator.dataRules(j), a.validator.staticRules(j)), j), g.required && (h = g.required, delete g.required, g = a.extend({
+                required: h
+            }, g), a(j).attr("aria-required", "true")), g.remote && (h = g.remote, delete g.remote, g = a.extend(g, {
+                remote: h
+            })), g
+        }
+    }), a.extend(a.expr[":"], {
+        blank: function(b) {
+            return !a.trim("" + a(b).val())
+        },
+        filled: function(b) {
+            return !!a.trim("" + a(b).val())
+        },
+        unchecked: function(b) {
+            return !a(b).prop("checked")
+        }
+    }), a.validator = function(b, c) {
+        this.settings = a.extend(!0, {}, a.validator.defaults, b), this.currentForm = c, this.init()
+    }, a.validator.format = function(b, c) {
+        return 1 === arguments.length ? function() {
+                var c = a.makeArray(arguments);
+                return c.unshift(b), a.validator.format.apply(this, c)
+            } : (arguments.length > 2 && c.constructor !== Array && (c = a.makeArray(arguments).slice(1)), c.constructor !== Array && (c = [c]), a.each(c, function(a, c) {
+                b = b.replace(new RegExp("\\{" + a + "\\}", "g"), function() {
+                    return c
+                })
+            }), b)
+    }, a.extend(a.validator, {
+        defaults: {
+            messages: {},
+            groups: {},
+            rules: {},
+            errorClass: "error",
+            validClass: "valid",
+            errorElement: "label",
+            focusInvalid: !0,
+            errorContainer: a([]),
+            errorLabelContainer: a([]),
+            onsubmit: !0,
+            ignore: ":hidden",
+            ignoreTitle: !1,
+            onfocusin: function(a) {
+                this.lastActive = a, this.settings.focusCleanup && !this.blockFocusCleanup && (this.settings.unhighlight && this.settings.unhighlight.call(this, a, this.settings.errorClass, this.settings.validClass), this.addWrapper(this.errorsFor(a)).hide())
+            },
+            onfocusout: function(a) {
+                this.checkable(a) || !(a.name in this.submitted) && this.optional(a) || this.element(a)
+            },
+            onkeyup: function(a, b) {
+                (9 !== b.which || "" !== this.elementValue(a)) && (a.name in this.submitted || a === this.lastElement) && this.element(a)
+            },
+            onclick: function(a) {
+                a.name in this.submitted ? this.element(a) : a.parentNode.name in this.submitted && this.element(a.parentNode)
+            },
+            highlight: function(b, c, d) {
+                "radio" === b.type ? this.findByName(b.name).addClass(c).removeClass(d) : a(b).addClass(c).removeClass(d)
+            },
+            unhighlight: function(b, c, d) {
+                "radio" === b.type ? this.findByName(b.name).removeClass(c).addClass(d) : a(b).removeClass(c).addClass(d)
+            }
+        },
+        setDefaults: function(b) {
+            a.extend(a.validator.defaults, b)
+        },
+        messages: {
+            required: "This field is required.",
+            remote: "Please fix this field.",
+            email: "Please enter a valid email address.",
+            url: "Please enter a valid URL.",
+            date: "Please enter a valid date.",
+            dateISO: "Please enter a valid date (ISO).",
+            number: "Please enter a valid number.",
+            digits: "Please enter only digits.",
+            creditcard: "Please enter a valid credit card number.",
+            equalTo: "Please enter the same value again.",
+            maxlength: a.validator.format("Please enter no more than {0} characters."),
+            minlength: a.validator.format("Please enter at least {0} characters."),
+            rangelength: a.validator.format("Please enter a value between {0} and {1} characters long."),
+            range: a.validator.format("Please enter a value between {0} and {1}."),
+            max: a.validator.format("Please enter a value less than or equal to {0}."),
+            min: a.validator.format("Please enter a value greater than or equal to {0}.")
+        },
+        autoCreateRanges: !1,
+        prototype: {
+            init: function() {
+                function b(b) {
+                    var c = a.data(this[0].form, "validator"),
+                        d = "on" + b.type.replace(/^validate/, ""),
+                        e = c.settings;
+                    e[d] && !this.is(e.ignore) && e[d].call(c, this[0], b)
+                }
+                this.labelContainer = a(this.settings.errorLabelContainer), this.errorContext = this.labelContainer.length && this.labelContainer || a(this.currentForm), this.containers = a(this.settings.errorContainer).add(this.settings.errorLabelContainer), this.submitted = {}, this.valueCache = {}, this.pendingRequest = 0, this.pending = {}, this.invalid = {}, this.reset();
+                var c, d = this.groups = {};
+                a.each(this.settings.groups, function(b, c) {
+                    "string" == typeof c && (c = c.split(/\s/)), a.each(c, function(a, c) {
+                        d[c] = b
+                    })
+                }), c = this.settings.rules, a.each(c, function(b, d) {
+                    c[b] = a.validator.normalizeRule(d)
+                }), a(this.currentForm).validateDelegate(":text, [type='password'], [type='file'], select, textarea, [type='number'], [type='search'] ,[type='tel'], [type='url'], [type='email'], [type='datetime'], [type='date'], [type='month'], [type='week'], [type='time'], [type='datetime-local'], [type='range'], [type='color'] ", "focusin focusout keyup", b).validateDelegate("[type='radio'], [type='checkbox'], select, option", "click", b), this.settings.invalidHandler && a(this.currentForm).bind("invalid-form.validate", this.settings.invalidHandler), a(this.currentForm).find("[required], [data-rule-required], .required").attr("aria-required", "true")
+            },
+            form: function() {
+                return this.checkForm(), a.extend(this.submitted, this.errorMap), this.invalid = a.extend({}, this.errorMap), this.valid() || a(this.currentForm).triggerHandler("invalid-form", [this]), this.showErrors(), this.valid()
+            },
+            checkForm: function() {
+                this.prepareForm();
+                for (var a = 0, b = this.currentElements = this.elements(); b[a]; a++) this.check(b[a]);
+                return this.valid()
+            },
+            element: function(b) {
+                var c = this.clean(b),
+                    d = this.validationTargetFor(c),
+                    e = !0;
+                return this.lastElement = d, void 0 === d ? delete this.invalid[c.name] : (this.prepareElement(d), this.currentElements = a(d), e = this.check(d) !== !1, e ? delete this.invalid[d.name] : this.invalid[d.name] = !0), a(b).attr("aria-invalid", !e), this.numberOfInvalids() || (this.toHide = this.toHide.add(this.containers)), this.showErrors(), e
+            },
+            showErrors: function(b) {
+                if (b) {
+                    a.extend(this.errorMap, b), this.errorList = [];
+                    for (var c in b) this.errorList.push({
+                        message: b[c],
+                        element: this.findByName(c)[0]
+                    });
+                    this.successList = a.grep(this.successList, function(a) {
+                        return !(a.name in b)
+                    })
+                }
+                this.settings.showErrors ? this.settings.showErrors.call(this, this.errorMap, this.errorList) : this.defaultShowErrors()
+            },
+            resetForm: function() {
+                a.fn.resetForm && a(this.currentForm).resetForm(), this.submitted = {}, this.lastElement = null, this.prepareForm(), this.hideErrors(), this.elements().removeClass(this.settings.errorClass).removeData("previousValue").removeAttr("aria-invalid")
+            },
+            numberOfInvalids: function() {
+                return this.objectLength(this.invalid)
+            },
+            objectLength: function(a) {
+                var b, c = 0;
+                for (b in a) c++;
+                return c
+            },
+            hideErrors: function() {
+                this.addWrapper(this.toHide).hide()
+            },
+            valid: function() {
+                return 0 === this.size()
+            },
+            size: function() {
+                return this.errorList.length
+            },
+            focusInvalid: function() {
+                if (this.settings.focusInvalid) try {
+                    a(this.findLastActive() || this.errorList.length && this.errorList[0].element || []).filter(":visible").focus().trigger("focusin")
+                } catch (b) {}
+            },
+            findLastActive: function() {
+                var b = this.lastActive;
+                return b && 1 === a.grep(this.errorList, function(a) {
+                        return a.element.name === b.name
+                    }).length && b
+            },
+            elements: function() {
+                var b = this,
+                    c = {};
+                return a(this.currentForm).find("input, select, textarea").not(":submit, :reset, :image, [disabled]").not(this.settings.ignore).filter(function() {
+                    return !this.name && b.settings.debug && window.console && console.error("%o has no name assigned", this), this.name in c || !b.objectLength(a(this).rules()) ? !1 : (c[this.name] = !0, !0)
+                })
+            },
+            clean: function(b) {
+                return a(b)[0]
+            },
+            errors: function() {
+                var b = this.settings.errorClass.split(" ").join(".");
+                return a(this.settings.errorElement + "." + b, this.errorContext)
+            },
+            reset: function() {
+                this.successList = [], this.errorList = [], this.errorMap = {}, this.toShow = a([]), this.toHide = a([]), this.currentElements = a([])
+            },
+            prepareForm: function() {
+                this.reset(), this.toHide = this.errors().add(this.containers)
+            },
+            prepareElement: function(a) {
+                this.reset(), this.toHide = this.errorsFor(a)
+            },
+            elementValue: function(b) {
+                var c, d = a(b),
+                    e = d.attr("type");
+                return "radio" === e || "checkbox" === e ? a("input[name='" + d.attr("name") + "']:checked").val() : (c = d.val(), "string" == typeof c ? c.replace(/\r/g, "") : c)
+            },
+            check: function(b) {
+                b = this.validationTargetFor(this.clean(b));
+                var c, d, e, f = a(b).rules(),
+                    g = a.map(f, function(a, b) {
+                        return b
+                    }).length,
+                    h = !1,
+                    i = this.elementValue(b);
+                for (d in f) {
+                    e = {
+                        method: d,
+                        parameters: f[d]
+                    };
+                    try {
+                        if (c = a.validator.methods[d].call(this, i, b, e.parameters), "dependency-mismatch" === c && 1 === g) {
+                            h = !0;
+                            continue
+                        }
+                        if (h = !1, "pending" === c) return void(this.toHide = this.toHide.not(this.errorsFor(b)));
+                        if (!c) return this.formatAndAdd(b, e), !1
+                    } catch (j) {
+                        throw this.settings.debug && window.console && console.log("Exception occurred when checking element " + b.id + ", check the '" + e.method + "' method.", j), j
+                    }
+                }
+                if (!h) return this.objectLength(f) && this.successList.push(b), !0
+            },
+            customDataMessage: function(b, c) {
+                return a(b).data("msg" + c[0].toUpperCase() + c.substring(1).toLowerCase()) || a(b).data("msg")
+            },
+            customMessage: function(a, b) {
+                var c = this.settings.messages[a];
+                return c && (c.constructor === String ? c : c[b])
+            },
+            findDefined: function() {
+                for (var a = 0; a < arguments.length; a++)
+                    if (void 0 !== arguments[a]) return arguments[a];
+                return void 0
+            },
+            defaultMessage: function(b, c) {
+                return this.findDefined(this.customMessage(b.name, c), this.customDataMessage(b, c), !this.settings.ignoreTitle && b.title || void 0, a.validator.messages[c], "<strong>Warning: No message defined for " + b.name + "</strong>")
+            },
+            formatAndAdd: function(b, c) {
+                var d = this.defaultMessage(b, c.method),
+                    e = /\$?\{(\d+)\}/g;
+                "function" == typeof d ? d = d.call(this, c.parameters, b) : e.test(d) && (d = a.validator.format(d.replace(e, "{$1}"), c.parameters)), this.errorList.push({
+                    message: d,
+                    element: b,
+                    method: c.method
+                }), this.errorMap[b.name] = d, this.submitted[b.name] = d
+            },
+            addWrapper: function(a) {
+                return this.settings.wrapper && (a = a.add(a.parent(this.settings.wrapper))), a
+            },
+            defaultShowErrors: function() {
+                var a, b, c;
+                for (a = 0; this.errorList[a]; a++) c = this.errorList[a], this.settings.highlight && this.settings.highlight.call(this, c.element, this.settings.errorClass, this.settings.validClass), this.showLabel(c.element, c.message);
+                if (this.errorList.length && (this.toShow = this.toShow.add(this.containers)), this.settings.success)
+                    for (a = 0; this.successList[a]; a++) this.showLabel(this.successList[a]);
+                if (this.settings.unhighlight)
+                    for (a = 0, b = this.validElements(); b[a]; a++) this.settings.unhighlight.call(this, b[a], this.settings.errorClass, this.settings.validClass);
+                this.toHide = this.toHide.not(this.toShow), this.hideErrors(), this.addWrapper(this.toShow).show()
+            },
+            validElements: function() {
+                return this.currentElements.not(this.invalidElements())
+            },
+            invalidElements: function() {
+                return a(this.errorList).map(function() {
+                    return this.element
+                })
+            },
+            showLabel: function(b, c) {
+                var d = this.errorsFor(b);
+                d.length ? (d.removeClass(this.settings.validClass).addClass(this.settings.errorClass), d.html(c)) : (d = a("<" + this.settings.errorElement + ">").attr("for", this.idOrName(b)).addClass(this.settings.errorClass).html(c || ""), this.settings.wrapper && (d = d.hide().show().wrap("<" + this.settings.wrapper + "/>").parent()), this.labelContainer.append(d).length || (this.settings.errorPlacement ? this.settings.errorPlacement(d, a(b)) : d.insertAfter(b))), !c && this.settings.success && (d.text(""), "string" == typeof this.settings.success ? d.addClass(this.settings.success) : this.settings.success(d, b)), this.toShow = this.toShow.add(d)
+            },
+            errorsFor: function(b) {
+                var c = this.idOrName(b);
+                return this.errors().filter(function() {
+                    return a(this).attr("for") === c
+                })
+            },
+            idOrName: function(a) {
+                return this.groups[a.name] || (this.checkable(a) ? a.name : a.id || a.name)
+            },
+            validationTargetFor: function(a) {
+                return this.checkable(a) && (a = this.findByName(a.name).not(this.settings.ignore)[0]), a
+            },
+            checkable: function(a) {
+                return /radio|checkbox/i.test(a.type)
+            },
+            findByName: function(b) {
+                return a(this.currentForm).find("[name='" + b + "']")
+            },
+            getLength: function(b, c) {
+                switch (c.nodeName.toLowerCase()) {
+                    case "select":
+                        return a("option:selected", c).length;
+                    case "input":
+                        if (this.checkable(c)) return this.findByName(c.name).filter(":checked").length
+                }
+                return b.length
+            },
+            depend: function(a, b) {
+                return this.dependTypes[typeof a] ? this.dependTypes[typeof a](a, b) : !0
+            },
+            dependTypes: {
+                "boolean": function(a) {
+                    return a
+                },
+                string: function(b, c) {
+                    return !!a(b, c.form).length
+                },
+                "function": function(a, b) {
+                    return a(b)
+                }
+            },
+            optional: function(b) {
+                var c = this.elementValue(b);
+                return !a.validator.methods.required.call(this, c, b) && "dependency-mismatch"
+            },
+            startRequest: function(a) {
+                this.pending[a.name] || (this.pendingRequest++, this.pending[a.name] = !0)
+            },
+            stopRequest: function(b, c) {
+                this.pendingRequest--, this.pendingRequest < 0 && (this.pendingRequest = 0), delete this.pending[b.name], c && 0 === this.pendingRequest && this.formSubmitted && this.form() ? (a(this.currentForm).submit(), this.formSubmitted = !1) : !c && 0 === this.pendingRequest && this.formSubmitted && (a(this.currentForm).triggerHandler("invalid-form", [this]), this.formSubmitted = !1)
+            },
+            previousValue: function(b) {
+                return a.data(b, "previousValue") || a.data(b, "previousValue", {
+                        old: null,
+                        valid: !0,
+                        message: this.defaultMessage(b, "remote")
+                    })
+            }
+        },
+        classRuleSettings: {
+            required: {
+                required: !0
+            },
+            email: {
+                email: !0
+            },
+            url: {
+                url: !0
+            },
+            date: {
+                date: !0
+            },
+            dateISO: {
+                dateISO: !0
+            },
+            number: {
+                number: !0
+            },
+            digits: {
+                digits: !0
+            },
+            creditcard: {
+                creditcard: !0
+            }
+        },
+        addClassRules: function(b, c) {
+            b.constructor === String ? this.classRuleSettings[b] = c : a.extend(this.classRuleSettings, b)
+        },
+        classRules: function(b) {
+            var c = {},
+                d = a(b).attr("class");
+            return d && a.each(d.split(" "), function() {
+                this in a.validator.classRuleSettings && a.extend(c, a.validator.classRuleSettings[this])
+            }), c
+        },
+        attributeRules: function(b) {
+            var c, d, e = {},
+                f = a(b),
+                g = b.getAttribute("type");
+            for (c in a.validator.methods) "required" === c ? (d = b.getAttribute(c), "" === d && (d = !0), d = !!d) : d = f.attr(c), /min|max/.test(c) && (null === g || /number|range|text/.test(g)) && (d = Number(d)), d || 0 === d ? e[c] = d : g === c && "range" !== g && (e[c] = !0);
+            return e.maxlength && /-1|2147483647|524288/.test(e.maxlength) && delete e.maxlength, e
+        },
+        dataRules: function(b) {
+            var c, d, e = {},
+                f = a(b);
+            for (c in a.validator.methods) d = f.data("rule" + c[0].toUpperCase() + c.substring(1).toLowerCase()), void 0 !== d && (e[c] = d);
+            return e
+        },
+        staticRules: function(b) {
+            var c = {},
+                d = a.data(b.form, "validator");
+            return d.settings.rules && (c = a.validator.normalizeRule(d.settings.rules[b.name]) || {}), c
+        },
+        normalizeRules: function(b, c) {
+            return a.each(b, function(d, e) {
+                if (e === !1) return void delete b[d];
+                if (e.param || e.depends) {
+                    var f = !0;
+                    switch (typeof e.depends) {
+                        case "string":
+                            f = !!a(e.depends, c.form).length;
+                            break;
+                        case "function":
+                            f = e.depends.call(c, c)
+                    }
+                    f ? b[d] = void 0 !== e.param ? e.param : !0 : delete b[d]
+                }
+            }), a.each(b, function(d, e) {
+                b[d] = a.isFunction(e) ? e(c) : e
+            }), a.each(["minlength", "maxlength"], function() {
+                b[this] && (b[this] = Number(b[this]))
+            }), a.each(["rangelength", "range"], function() {
+                var c;
+                b[this] && (a.isArray(b[this]) ? b[this] = [Number(b[this][0]), Number(b[this][1])] : "string" == typeof b[this] && (c = b[this].split(/[\s,]+/), b[this] = [Number(c[0]), Number(c[1])]))
+            }), a.validator.autoCreateRanges && (b.min && b.max && (b.range = [b.min, b.max], delete b.min, delete b.max), b.minlength && b.maxlength && (b.rangelength = [b.minlength, b.maxlength], delete b.minlength, delete b.maxlength)), b
+        },
+        normalizeRule: function(b) {
+            if ("string" == typeof b) {
+                var c = {};
+                a.each(b.split(/\s/), function() {
+                    c[this] = !0
+                }), b = c
+            }
+            return b
+        },
+        addMethod: function(b, c, d) {
+            a.validator.methods[b] = c, a.validator.messages[b] = void 0 !== d ? d : a.validator.messages[b], c.length < 3 && a.validator.addClassRules(b, a.validator.normalizeRule(b))
+        },
+        methods: {
+            required: function(b, c, d) {
+                if (!this.depend(d, c)) return "dependency-mismatch";
+                if ("select" === c.nodeName.toLowerCase()) {
+                    var e = a(c).val();
+                    return e && e.length > 0
+                }
+                return this.checkable(c) ? this.getLength(b, c) > 0 : a.trim(b).length > 0
+            },
+            email: function(a, b) {
+                return this.optional(b) || /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(a)
+            },
+            url: function(a, b) {
+                return this.optional(b) || /^(https?|s?ftp):\/\/(((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:)*@)?(((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))|((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?)(:\d*)?)(\/((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)+(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)*)*)?)?(\?((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|[\uE000-\uF8FF]|\/|\?)*)?(#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|\/|\?)*)?$/i.test(a)
+            },
+            date: function(a, b) {
+                return this.optional(b) || !/Invalid|NaN/.test(new Date(a).toString())
+            },
+            dateISO: function(a, b) {
+                return this.optional(b) || /^\d{4}[\/\-]\d{1,2}[\/\-]\d{1,2}$/.test(a)
+            },
+            number: function(a, b) {
+                return this.optional(b) || /^-?(?:\d+|\d{1,3}(?:,\d{3})+)?(?:\.\d+)?$/.test(a)
+            },
+            digits: function(a, b) {
+                return this.optional(b) || /^\d+$/.test(a)
+            },
+            creditcard: function(a, b) {
+                if (this.optional(b)) return "dependency-mismatch";
+                if (/[^0-9 \-]+/.test(a)) return !1;
+                var c, d, e = 0,
+                    f = 0,
+                    g = !1;
+                if (a = a.replace(/\D/g, ""), a.length < 13 || a.length > 19) return !1;
+                for (c = a.length - 1; c >= 0; c--) d = a.charAt(c), f = parseInt(d, 10), g && (f *= 2) > 9 && (f -= 9), e += f, g = !g;
+                return e % 10 === 0
+            },
+            minlength: function(b, c, d) {
+                var e = a.isArray(b) ? b.length : this.getLength(a.trim(b), c);
+                return this.optional(c) || e >= d
+            },
+            maxlength: function(b, c, d) {
+                var e = a.isArray(b) ? b.length : this.getLength(a.trim(b), c);
+                return this.optional(c) || d >= e
+            },
+            rangelength: function(b, c, d) {
+                var e = a.isArray(b) ? b.length : this.getLength(a.trim(b), c);
+                return this.optional(c) || e >= d[0] && e <= d[1]
+            },
+            min: function(a, b, c) {
+                return this.optional(b) || a >= c
+            },
+            max: function(a, b, c) {
+                return this.optional(b) || c >= a
+            },
+            range: function(a, b, c) {
+                return this.optional(b) || a >= c[0] && a <= c[1]
+            },
+            equalTo: function(b, c, d) {
+                var e = a(d);
+                return this.settings.onfocusout && e.unbind(".validate-equalTo").bind("blur.validate-equalTo", function() {
+                    a(c).valid()
+                }), b === e.val()
+            },
+            remote: function(b, c, d) {
+                if (this.optional(c)) return "dependency-mismatch";
+                var e, f, g = this.previousValue(c);
+                return this.settings.messages[c.name] || (this.settings.messages[c.name] = {}), g.originalMessage = this.settings.messages[c.name].remote, this.settings.messages[c.name].remote = g.message, d = "string" == typeof d && {
+                        url: d
+                    } || d, g.old === b ? g.valid : (g.old = b, e = this, this.startRequest(c), f = {}, f[c.name] = b, a.ajax(a.extend(!0, {
+                        url: d,
+                        mode: "abort",
+                        port: "validate" + c.name,
+                        dataType: "json",
+                        data: f,
+                        context: e.currentForm,
+                        success: function(d) {
+                            var f, h, i, j = d === !0 || "true" === d;
+                            e.settings.messages[c.name].remote = g.originalMessage, j ? (i = e.formSubmitted, e.prepareElement(c), e.formSubmitted = i, e.successList.push(c), delete e.invalid[c.name], e.showErrors()) : (f = {}, h = d || e.defaultMessage(c, "remote"), f[c.name] = g.message = a.isFunction(h) ? h(b) : h, e.invalid[c.name] = !0, e.showErrors(f)), g.valid = j, e.stopRequest(c, j)
+                        }
+                    }, d)), "pending")
+            }
+        }
+    }), a.format = function() {
+        throw "$.format has been deprecated. Please use $.validator.format instead."
+    }
+}(jQuery),
+    function(a) {
+        var b, c = {};
+        a.ajaxPrefilter ? a.ajaxPrefilter(function(a, b, d) {
+                var e = a.port;
+                "abort" === a.mode && (c[e] && c[e].abort(), c[e] = d)
+            }) : (b = a.ajax, a.ajax = function(d) {
+                var e = ("mode" in d ? d : a.ajaxSettings).mode,
+                    f = ("port" in d ? d : a.ajaxSettings).port;
+                return "abort" === e ? (c[f] && c[f].abort(), c[f] = b.apply(this, arguments), c[f]) : b.apply(this, arguments)
+            })
+    }(jQuery),
+    function(a) {
+        a.extend(a.fn, {
+            validateDelegate: function(b, c, d) {
+                return this.bind(c, function(c) {
+                    var e = a(c.target);
+                    return e.is(b) ? d.apply(e, arguments) : void 0
+                })
+            }
+        })
+    }(jQuery);
+
+// ADDITIONAL JQUERY VALIDATE METHODS
+(function($) {
+    // Validate a multifield birthday
+    $.validator.addMethod("mc_birthday", function(date, element, grouping_class) {
+        var isValid = false;
+        var $fields = $('input:not(:hidden)', $(element).closest(grouping_class));
+        if ($fields.filter(':filled').length == 0 && this.optional(element)) {
+            isValid = true; // None have been filled out, so no error
+        } else {
+            var dateArray = new Array();
+            dateArray['month'] = $fields.filter("input[name*='[month]']").val();
+            dateArray['day'] = $fields.filter("input[name*='[day]']").val();
+
+            // correct month value
+            dateArray['month'] = dateArray['month'] - 1;
+
+            var testDate = new Date(1970, dateArray['month'], dateArray['day']);
+            if (testDate.getDate() != dateArray['day'] || testDate.getMonth() != dateArray['month']) {
+                isValid = false;
+            } else {
+                isValid = true;
+            }
+        }
+        return isValid;
+    }, "Please enter a valid month and day.");
+    // Validate a multifield date
+    $.validator.addMethod("mc_date", function(date, element, grouping_class) {
+        var isValid = false;
+        var $fields = $('input:not(:hidden)', $(element).closest(grouping_class));
+        if ($fields.filter(':filled').length == 0 && this.optional(element)) {
+            isValid = true; // None have been filled out, so no error
+        } else {
+            var dateArray = new Array();
+            dateArray['month'] = $fields.filter("input[name*='[month]']").val();
+            dateArray['day'] = $fields.filter("input[name*='[day]']").val();
+            dateArray['year'] = $fields.filter("input[name*='[year]']").val();
+
+            // correct month value
+            dateArray['month'] = dateArray['month'] - 1;
+
+            // correct year value
+            if (dateArray['year'].length < 4) {
+                dateArray['year'] = (parseInt(dateArray['year']) < 50) ? 2000 + parseInt(dateArray['year']) : 1900 + parseInt(dateArray['year']);
+            }
+
+            var testDate = new Date(dateArray['year'], dateArray['month'], dateArray['day']);
+            if (testDate.getDate() != dateArray['day'] || testDate.getMonth() != dateArray['month'] || testDate.getFullYear() != dateArray['year']) {
+                isValid = false;
+            } else {
+                isValid = true;
+            }
+        }
+        return isValid;
+    }, "Please enter a valid date");
+
+    // Validate a multifield phone number
+    $.validator.addMethod("mc_phone", function(phone_number, element, grouping_class) {
+        var isValid = false;
+        var $fields = $('input:filled:not(:hidden)', $(element).closest(grouping_class));
+        if ($fields.length == 0 && this.optional(element)) {
+            isValid = true; // None have been filled out, so no error
+        } else {
+            phone_number = $fields.eq(0).val() + $fields.eq(1).val() + $fields.eq(2).val();
+            isValid = phone_number.length == 10 && phone_number.match(/[0-9]{9}/);
+        }
+        return isValid;
+    }, "Please specify a valid phone number");
+
+    $.validator.addMethod("skip_or_complete_group", function(value, element, grouping_class) {
+        var $fields = $('input:not(:hidden)', $(element).closest(grouping_class)),
+            $fieldsFirst = $fields.eq(0),
+            validator = $fieldsFirst.data("valid_skip") ? $fieldsFirst.data("valid_skip") : $.extend({}, this),
+            numberFilled = $fields.filter(function() {
+                return validator.elementValue(this);
+            }).length,
+            isValid = numberFilled === 0 || numberFilled === $fields.length;
+
+        // Store the cloned validator for future validation
+        $fieldsFirst.data("valid_skip", validator);
+
+        // If element isn't being validated, run each field's validation rules
+        if (!$(element).data("being_validated")) {
+            $fields.data("being_validated", true);
+            $fields.each(function() {
+                validator.element(this);
+            });
+            $fields.data("being_validated", false);
+        }
+        return isValid;
+    }, $.validator.format("Please supply missing fields."));
+
+    $.validator.addMethod("skip_or_fill_minimum", function(value, element, options) {
+        var $fields = $(options[1], element.form),
+            $fieldsFirst = $fields.eq(0),
+            validator = $fieldsFirst.data("valid_skip") ? $fieldsFirst.data("valid_skip") : $.extend({}, this),
+            numberFilled = $fields.filter(function() {
+                return validator.elementValue(this);
+            }).length,
+            isValid = numberFilled === 0 || numberFilled >= options[0];
+        console.log($fields.eq(0));
+        // Store the cloned validator for future validation
+        $fieldsFirst.data("valid_skip", validator);
+
+        // If element isn't being validated, run each skip_or_fill_minimum field's validation rules
+        if (!$(element).data("being_validated")) {
+            $fields.data("being_validated", true);
+            $fields.each(function() {
+                validator.element(this);
+            });
+            $fields.data("being_validated", false);
+        }
+        return isValid;
+    }, $.validator.format("Please either skip these fields or fill at least {0} of them."));
+
+    $.validator.addMethod("zipcodeUS", function(value, element) {
+        return this.optional(element) || /^\d{5}-\d{4}$|^\d{5}$/.test(value);
+    }, "The specified US ZIP Code is invalid");
+
+}(jQuery));
+
+// MC
+(function($) {
+    var err_style = '';
+    try {
+        err_style = mc_custom_error_style;
+    } catch (e) {
+        err_style = '#mc_embed_signup input.mce_inline_error { border-color:#6B0505; } #mc_embed_signup div.mce_inline_error { margin: 0 0 1em 0; padding: 5px 10px; background-color:#6B0505; font-weight: bold; z-index: 1; color:#fff; }';
+    }
+    var head = document.getElementsByTagName('head')[0];
+    var style = document.createElement('style');
+    style.type = 'text/css';
+    if (style.styleSheet) {
+        style.styleSheet.cssText = err_style;
+    } else {
+        style.appendChild(document.createTextNode(err_style));
+    }
+    head.appendChild(style);
+
+    // Expose extra mc form methods in global var
+    window.mc = {
+        openPopup: function() {
+            $('#mc_embed_signup a.mc_embed_close').show();
+            setTimeout(function() {
+                $('#mc_embed_signup').fadeIn();
+            }, mc.delayPopup);
+        },
+        closePopup: function() {
+            $('#mc_embed_signup').hide();
+            var now = new Date();
+            var expires_date = new Date(now.getTime() + 31536000000);
+            document.cookie = 'MCEvilPopupClosed=yes;expires=' + expires_date.toGMTString() + ';path=/';
+        },
+        /**
+         *	Figure out if we should show the popup (if they've closed it before, don't show it.)
+         */
+        evalPopup: function() {
+            $('#mc_embed_signup').hide();
+            cks = document.cookie.split(';');
+            for (i = 0; i < cks.length; i++) {
+                parts = cks[i].split('=');
+                if (parts[0].indexOf('MCEvilPopupClosed') != -1) mc.showPopup = false;
+            }
+            if (mc.showPopup) mc.openPopup();
+        },
+        /**
+         *	Grab the list subscribe url from the form action and make it work for an ajax post.
+         */
+        getAjaxSubmitUrl: function() {
+            var url = $("form#mc-embedded-subscribe-form").attr("action");
+            url = url.replace("/post?u=", "/post-json?u=");
+            url += "&c=?";
+            return url;
+        },
+        /**
+         *	Classify text inputs in the same field group as group for validation purposes.
+         *	All this does is tell jQueryValidation to create one error div for the group, rather
+         *	than one for each input. Primary use case is birthday and date fields, where we want
+         *	to display errors about the inputs collectively, not individually.
+         *
+         *	NOTE: Grouping inputs will give you one error div, but you still need to specify where
+         *	that div should be displayed. By default, it's inserted after the first input with a
+         *	validation error, which can break up a set of inputs. Use the errorPlacement setting in
+         *	the validator to control error div placement.
+         */
+        getGroups: function() {
+            var groups = {};
+            $(".mc-field-group").each(function(index) {
+                var inputs = $(this).find("input:text:not(:hidden)");
+                if (inputs.length > 1) {
+                    var mergeName = inputs.first().attr("name");
+                    var fieldNames = $.map(inputs, function(f) {
+                        return f.name;
+                    });
+                    groups[mergeName.substring(0, mergeName.indexOf("["))] = fieldNames.join(" ");
+                }
+            });
+            return groups;
+        },
+        /**
+         *	Check if a field is part of a multipart field
+         * 	(e.g., A date merge field is composed of individual inputs for month, day and year)
+         *	Used in jQuery validation onkeyup method to ensure that we don't evaluate a field
+         *  if a user hasn't reached the last input in a multipart field yet.
+         */
+        isMultiPartField: function(element) {
+            return ($('input:not(:hidden)', $(element).closest(".mc-field-group")).length > 1);
+        },
+        /**
+         *	Checks if the element is the last input in its fieldgroup.
+         *	If the field is not the last in a set of inputs we don't want to validate it on certain events (onfocusout, onblur)
+         *	because the user might not be finished yet.
+         */
+        isTooEarly: function(element) {
+            var fields = $('input:not(:hidden)', $(element).closest(".mc-field-group"));
+            return ($(fields).eq(-1).attr('id') != $(element).attr('id'));
+        },
+        /**
+         *	Handle the error/success message after successful form submission.
+         *	Success messages are appended to #mce-success-response
+         *	Error messages are displayed with the invalid input when possible, or appended to #mce-error-response
+         */
+        mce_success_cb: function(resp) {
+
+            $('#mce-success-response').hide();
+            $('#mce-error-response').hide();
+
+            // On successful form submission, display a success message and reset the form
+            if (resp.result == "success") {
+                $('#mce-' + resp.result + '-response').show();
+                $('#mce-' + resp.result + '-response').html(resp.msg);
+                $('#mc-embedded-subscribe-form').each(function() {
+                    this.reset();
+                });
+
+                // If the form has errors, display them, inline if possible, or appended to #mce-error-response
+            } else {
+
+                // Example errors - Note: You only get one back at a time even if you submit several that are bad.
+                // Error structure - number indicates the index of the merge field that was invalid, then details
+                // Object {result: "error", msg: "6 - Please enter the date"}
+                // Object {result: "error", msg: "4 - Please enter a value"}
+                // Object {result: "error", msg: "9 - Please enter a complete address"}
+
+                // Try to parse the error into a field index and a message.
+                // On failure, just put the dump thing into in the msg variable.
+                var index = -1;
+                var msg;
+                try {
+                    var parts = resp.msg.split(' - ', 2);
+                    if (parts[1] == undefined) {
+                        msg = resp.msg;
+                    } else {
+                        i = parseInt(parts[0]);
+                        if (i.toString() == parts[0]) {
+                            index = parts[0];
+                            msg = parts[1];
+                        } else {
+                            index = -1;
+                            msg = resp.msg;
+                        }
+                    }
+                } catch (e) {
+                    index = -1;
+                    msg = resp.msg;
+                }
+
+                try {
+                    // If index is -1 if means we don't have data on specifically which field was invalid.
+                    // Just lump the error message into the generic response div.
+                    if (index == -1) {
+                        $('#mce-' + resp.result + '-response').show();
+                        $('#mce-' + resp.result + '-response').html(msg);
+
+                    } else {
+                        var fieldName = $("input[name*='" + fnames[index] + "']").attr('name'); // Make sure this exists (they haven't deleted the fnames array lookup)
+                        var data = {};
+                        data[fieldName] = msg;
+                        mc.mce_validator.showErrors(data);
+                    }
+                } catch (e) {
+                    $('#mce-' + resp.result + '-response').show();
+                    $('#mce-' + resp.result + '-response').html(msg);
+                }
+            }
+        }
+    }
+
+    window.mc.mce_validator = $("#mc-embedded-subscribe-form").validate({
+
+        // Set error HTML: <div class="mce_inline_error"></div>
+        errorClass: "mce_inline_error",
+        errorElement: "div",
+
+        // Validate fields on keyup, focusout and blur.
+        onkeyup: false,
+        onfocusout: function(element) {
+            if (!mc.isTooEarly(element)) {
+                $(element).valid();
+            }
+        },
+        onblur: function(element) {
+            if (!mc.isTooEarly(element)) {
+                $(element).valid();
+            }
+        },
+        // Grouping fields makes jQuery Validation display one error for all the fields in the group
+        // It doesn't have anything to do with how the fields are validated (together or separately),
+        // it's strictly for visual display of errors
+        groups: mc.getGroups(),
+        // Place a field's inline error HTML just before the div.mc-field-group closing tag
+        errorPlacement: function(error, element) {
+            element.closest('.mc-field-group').append(error);
+        },
+        // Submit the form via ajax (see: jQuery Form plugin)
+        submitHandler: function(form) {
+            $(form).ajaxSubmit(mc.ajaxOptions);
+        }
+    });
+
+    window.mc.ajaxOptions = {
+        url: mc.getAjaxSubmitUrl(),
+        type: 'GET',
+        dataType: 'json',
+        contentType: "application/json; charset=utf-8",
+        success: mc.mce_success_cb
+    };
+
+    // Custom validation methods for fields with certain css classes
+    $.validator.addClassRules("birthday", {
+        digits: true,
+        mc_birthday: ".datefield"
+    });
+    $.validator.addClassRules("datepart", {
+        digits: true,
+        mc_date: ".datefield"
+    });
+    $.validator.addClassRules("phonepart", {
+        digits: true,
+        mc_phone: ".phonefield"
+    });
+
+    // Evil Popup
+    $('#mc_embed_signup a.mc_embed_close').click(function() {
+        mc.closePopup();
+    });
+    $(document).keydown(function(e) {
+        keycode = (e == null) ? event.keyCode : e.which;
+        if (keycode == 27 && typeof mc.showPopup != 'undefined') mc.closePopup();
+    });
+
+}(jQuery));

--- a/pages/footer-links/signup.html
+++ b/pages/footer-links/signup.html
@@ -73,7 +73,7 @@ searchexcerpt: "Sign-up to our mailing list and receive updates."
     </div>
   </form>
 </div>
-<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script>
+{% js mc-validate %}
 <script type='text/javascript'>(function ($) {
     window.fnames = new Array();
     window.ftypes = new Array();


### PR DESCRIPTION
This PR addresses issue #295 from the accessibility review.

Validation in the sign-up form is handled by the mailchimp supplied mc-validate.js.

This issue has been reported upstream to mailchimp. 

For now I have changed so this file is served locally, and hotfixed setting `aria-describedby` when the input fields are invalid as recommended in the accessibility review:

![image](https://cloud.githubusercontent.com/assets/2324569/23934944/e067afb0-099c-11e7-8cb3-ce4978e20d52.png)

You can see just the hotfix in this commit: https://github.com/AusDTO/dta-website/pull/381/commits/da0da9e06cc750c62e70096b187aec5de5e0ca38 

Preview link: https://1687-71211972-gh.circle-artifacts.com/0/home/ubuntu/dta-website/_site/signup/index.html

Closes #295