### PR TITLE
Add support for qafire

### DIFF
--- a/bin/buildrc
+++ b/bin/buildrc
@@ -12,7 +12,8 @@ readonly DEPLOY_BRANCHES="+(web-updates)"
 readonly GITBRANCH="$(git symbolic-ref --short -q HEAD)"
 
 # The appname used if we deploy with 'cf push appname'
-readonly CF_PUSH_APPNAME="${CIRCLE_PROJECT_REPONAME}-`basename \"${GITBRANCH}\"`"
+# (not used for master and develop, which use manifests instead)
+readonly CF_PUSH_APPNAME="pr-`basename ${CI_PULL_REQUEST}`-${CIRCLE_PROJECT_REPONAME}"
 
 # Use the branch name to set jekyll config:
 # - DTA_SITE_BASEURL - used in jekyll for site.baseurl
@@ -25,20 +26,8 @@ case "${GITBRANCH}" in
   develop)
     export DTA_SITE_URL="https://dta.apps.staging.digital.gov.au"
     ;;
-  ${DEPLOY_BRANCHES})
-    export DTA_SITE_URL="https://${CF_PUSH_APPNAME}.apps.staging.digital.gov.au"
-    ;;
   *)
-    if [[ -n ${CIRCLECI+x} ]]
-    then
-      # Configure jekyll to be statically hosted on circleci.
-      # TODO remove hardcoded parameters as much as possible - but where does 71211972 come from?
-      export DTA_SITE_URL="https://${CIRCLE_BUILD_NUM}-71211972-gh.circle-artifacts.com"
-      export DTA_SITE_BASEURL="/${CIRCLE_NODE_INDEX}${HOME}/${CIRCLE_PROJECT_REPONAME}/_site"
-    else
-      # Assume the site is being built locally for cloud foundry
-      export DTA_SITE_URL="https://${CF_PUSH_APPNAME}.apps.staging.digital.gov.au"
-    fi
+    export DTA_SITE_URL="https://${CF_PUSH_APPNAME}.apps.staging.digital.gov.au"
     ;;
 esac
 

--- a/bin/cideploy.sh
+++ b/bin/cideploy.sh
@@ -28,9 +28,6 @@ checkrepo() {
   fi
 }
 
-# We dont need to deploy the pa11y-sitemap.xml
-rm -f _site/pa11y-sitemap.xml
-
 # main script function
 #
 main() {
@@ -52,17 +49,18 @@ main() {
       cf target -s $CF_SPACE
       cf push -f manifest-develop.yml
       ;;
-    ${DEPLOY_BRANCHES})
-      basicauth
-      cf api $CF_STAGING_API
-      cf auth $CF_USER $CF_PASSWORD
-      cf target -o $CF_ORG
-      cf target -s $CF_SPACE
-      cf push "$CF_PUSH_APPNAME"
-      ;;
     *)
-      echo "I will not deploy this branch"
-      exit 0
+      if [[ "${CI_PULL_REQUEST}" == "" ]]
+      then
+        echo "I only deploy PRs"
+      else
+        basicauth
+        cf api $CF_STAGING_API
+        cf auth $CF_QAFIRE_USER $CF_QAFIRE_PASSWORD
+        cf target -o $CF_QAFIRE_ORG
+        cf target -s $CF_QAFIRE_SPACE
+        cf push "$CF_PUSH_APPNAME"
+      fi
       ;;
   esac
 }

--- a/bin/ciprepare.sh
+++ b/bin/ciprepare.sh
@@ -17,13 +17,12 @@ gem install --conservative bundler
 bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
 
 # install the cloud foundry cli tool if required
-case "${GITBRANCH}" in
-  master|develop|${DEPLOY_BRANCHES})
+if [[ "${GITBRANCH}" == "master" || "${GITBRANCH}" == "develop" || "${CI_PULL_REQUEST}" != "" ]]
+then
     curl -v -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&version=6.18.1&source=github-rel'
     sudo dpkg -i cf-cli_amd64.deb
     cf -v
-    ;;
-esac
+fi
 
 # htpasswd is needed when setting up basicauth
 if [[ -n ${CF_BASIC_AUTH_PASSWORD+x} ]]

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,3 +5,5 @@ instances: 1
 memory: 64M
 disk_quota: 256M
 buildpack: staticfile_buildpack
+qafire:
+  self_deployed: true


### PR DESCRIPTION
- Circle deploys the PR to https://pr-426-dta-website.apps.staging.digital.gov.au
- QAFire will not deploy, but will still update PR status with the link to the above.
- When the PR is closed, QA Fire will then delete the above app.

Note that since the deploy requires the PR number, Circle has been changed to only build when a PR is created. 