### PR TITLE
Fix firefox bug with homepage thumbnails

### DIFF
--- a/_assets/scss/partials/_list-vertical.scss
+++ b/_assets/scss/partials/_list-vertical.scss
@@ -3,6 +3,7 @@
 .list-vertical--fourths {
   div.link {
     padding-bottom:$small-spacing;
+    max-width: 100%;
     a {
       border-bottom: initial;
       &:hover {


### PR DESCRIPTION
Fixes #431.

Adding a max-width 100% to the image div fixes the issue on firefox. Have tested with browserstack to make sure it hasn't broken any others.