### PR TITLE
Increase html caching time

### DIFF
--- a/bin/cideploy.sh
+++ b/bin/cideploy.sh
@@ -28,15 +28,13 @@ checkrepo() {
   fi
 }
 
-# We dont need to deploy the pa11y-sitemap.xml
-rm -f _site/pa11y-sitemap.xml
-
 # main script function
 #
 main() {
   case "${GITBRANCH}" in
     master)
       checkrepo
+      mv _site/nginx-production.conf _site/nginx.conf
       cf api $CF_PROD_API
       cf auth $CF_USER $CF_PASSWORD
       cf target -o $CF_ORG

--- a/nginx-production.conf
+++ b/nginx-production.conf
@@ -35,7 +35,7 @@ http {
   # Expires map
   map $sent_http_content_type $expires {
     default                    off;
-    text/html                  epoch;
+    text/html                  5m;
     text/xml                   epoch;
     application/json           10m;
     text/css                   max;

--- a/nginx-production.conf
+++ b/nginx-production.conf
@@ -1,0 +1,81 @@
+##########################
+# This file was copied from https://github.com/cloudfoundry/staticfile-buildpack/tree/master/conf
+# and then modified for this app.
+##########################
+
+worker_processes 1;
+daemon off;
+
+error_log <%= ENV["APP_ROOT"] %>/nginx/logs/error.log;
+events { worker_connections 1024; }
+
+http {
+  charset utf-8;
+  log_format cloudfoundry '$http_x_forwarded_for - $http_referer - [$time_local] "$request" $status $body_bytes_sent';
+  access_log <%= ENV["APP_ROOT"] %>/nginx/logs/access.log cloudfoundry;
+  default_type application/octet-stream;
+  include mime.types;
+  sendfile on;
+
+  gzip on;
+  gzip_disable "msie6";
+  gzip_comp_level 6;
+  gzip_min_length 1100;
+  gzip_buffers 16 8k;
+  gzip_proxied any;
+  gunzip on;
+  gzip_static always;
+  gzip_types text/plain text/css text/js text/xml text/javascript application/javascript application/x-javascript application/json application/xml application/xml+rss;
+
+  tcp_nopush on;
+  keepalive_timeout 30;
+  port_in_redirect off; # Ensure that redirects don't include the internal container PORT - <%= ENV["PORT"] %>
+  server_tokens off;
+
+  # Expires map
+  map $sent_http_content_type $expires {
+    default                    off;
+    text/html                  epoch;
+    text/xml                   epoch;
+    application/json           10m;
+    text/css                   max;
+    application/javascript     max;
+    application/x-javascript   max;
+    application/pdf            1d;
+    ~image/                    1d;
+  }
+
+  server {
+    listen <%= ENV["PORT"] %>;
+    server_name localhost;
+
+    error_page 404 /404.html;
+
+    expires $expires;
+
+    location / {
+      root <%= ENV["APP_ROOT"] %>/public;
+      <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_pushstate")) %>
+      if (!-e $request_filename) {
+        rewrite ^(.*)$ / break;
+      }
+      <% end %>
+      index index.html index.htm Default.htm;
+      <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_directory_index")) %>
+        autoindex on;
+      <% end %>
+      <% if File.exists?(auth_file = File.join(ENV["APP_ROOT"], "nginx/conf/.htpasswd")) %>
+        auth_basic "Restricted";                                #For Basic Auth
+        auth_basic_user_file <%= auth_file %>;  #For Basic Auth
+      <% end %>
+      <% if ENV["FORCE_HTTPS"] %>
+        if ($http_x_forwarded_proto != "https") {
+          return 301 https://$host$request_uri;
+        }
+      <% end %>
+      <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_ssi")) %>
+        ssi on;
+      <% end %>
+    }
+  }
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -32,19 +32,6 @@ http {
   port_in_redirect off; # Ensure that redirects don't include the internal container PORT - <%= ENV["PORT"] %>
   server_tokens off;
 
-  # Expires map
-  map $sent_http_content_type $expires {
-    default                    off;
-    text/html                  epoch;
-    text/xml                   epoch;
-    application/json           10m;
-    text/css                   max;
-    application/javascript     max;
-    application/x-javascript   max;
-    application/pdf            1d;
-    ~image/                    1d;
-  }
-
   server {
     listen <%= ENV["PORT"] %>;
     server_name localhost;


### PR DESCRIPTION
This PR is an attempt to improve the caching performance on production from #370.

I have increased the caching of html content to 5 minutes. I'm hoping this will give cloud front enough time to propagate new pages so we don't get 404's. If this doesn't work we might have to look again into purging cloud front each deploy.

To prevent this new caching time being a nuisance in staging, I've added a separate nginx conf file `ngix-production.conf` to be used in production which has the previous caching settings. This is renamed to `nginx.conf` by the `cideploy.sh` when required. In non-production deploys a different nginx.conf will be used which does not have caching. 
