### PR TITLE
Remove http to https redirection

### DIFF
--- a/nginx-production.conf
+++ b/nginx-production.conf
@@ -70,11 +70,7 @@ http {
         auth_basic "Restricted";                                #For Basic Auth
         auth_basic_user_file <%= auth_file %>;  #For Basic Auth
       <% end %>
-      <% if ENV["FORCE_HTTPS"] %>
-        if ($http_x_forwarded_proto != "https") {
-          return 301 https://$host$request_uri;
-        }
-      <% end %>
+
       <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_ssi")) %>
         ssi on;
       <% end %>


### PR DESCRIPTION
It's safest to remove this entirely - in production this redirection should be handled by the CDN